### PR TITLE
Adjust mcore API

### DIFF
--- a/program-analysis/manticore/adding-constraints.md
+++ b/program-analysis/manticore/adding-constraints.md
@@ -89,6 +89,7 @@ Adding constraint to the previous code, we obtain:
 ```python3
 from manticore.ethereum import ManticoreEVM
 from manticore.core.smtlib.solver import Z3Solver
+ETHER = 10**18
 
 solver = Z3Solver.instance()
 
@@ -97,7 +98,7 @@ m = ManticoreEVM()
 with open("example.sol") as f:
     source_code = f.read()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 contract_account = m.solidity_create_contract(source_code, owner=user_account)
 
 symbolic_var = m.make_symbolic_value()

--- a/program-analysis/manticore/examples/example_constraint.py
+++ b/program-analysis/manticore/examples/example_constraint.py
@@ -1,8 +1,9 @@
 from manticore.ethereum import ManticoreEVM
+ETHER = 10**18
 
 m = ManticoreEVM()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 
 with open('example.sol') as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)

--- a/program-analysis/manticore/examples/example_run.py
+++ b/program-analysis/manticore/examples/example_run.py
@@ -1,9 +1,12 @@
+import os
 from manticore.ethereum import ManticoreEVM
 
 m = ManticoreEVM()
+filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'example.sol')
 
-user_account = m.create_account(balance=1000)
-with open('example.sol') as f:
+# Needs enough balance to pay for the gas of the initialization
+user_account = m.create_account(balance=10**10)
+with open(filename) as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)
 
 symbolic_var = m.make_symbolic_value()

--- a/program-analysis/manticore/examples/example_run.py
+++ b/program-analysis/manticore/examples/example_run.py
@@ -1,12 +1,11 @@
 import os
 from manticore.ethereum import ManticoreEVM
+ETHER = 10**18
 
 m = ManticoreEVM()
-filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'example.sol')
-
 # Needs enough balance to pay for the gas of the initialization
-user_account = m.create_account(balance=10**10)
-with open(filename) as f:
+user_account = m.create_account(balance=1*ETHER)
+with open('example.sol') as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)
 
 symbolic_var = m.make_symbolic_value()

--- a/program-analysis/manticore/examples/example_throw.py
+++ b/program-analysis/manticore/examples/example_throw.py
@@ -1,11 +1,12 @@
 from manticore.ethereum import ManticoreEVM
+ETHER = 10**18
 
 m = ManticoreEVM()
 
 with open('example.sol') as f:
     source_code = f.read()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 contract_account = m.solidity_create_contract(source_code,
                                               owner=user_account)
 

--- a/program-analysis/manticore/exercises/example/my_token.py
+++ b/program-analysis/manticore/exercises/example/my_token.py
@@ -1,15 +1,15 @@
 from manticore.ethereum import ManticoreEVM, ABI
 from manticore.core.smtlib import Operators, solver
+ETHER = 10**18
 
 ###### Initialization ######
-
 m = ManticoreEVM()
 with open('my_token.sol') as f:
     source_code = f.read()
 
 # Create one user account
 # And deploy the contract
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 contract_account = m.solidity_create_contract(source_code, owner=user_account, balance=0)
 
 ###### Exploration ######

--- a/program-analysis/manticore/exercises/example/my_token.py
+++ b/program-analysis/manticore/exercises/example/my_token.py
@@ -1,3 +1,11 @@
+from manticore.utils import config
+# Either wait for Z3 
+# consts = config.get_group("smt")
+# consts.timeout = 99999
+# Or just shift to yikes ...
+consts.solver = consts.solver.yices
+
+
 from manticore.ethereum import ManticoreEVM, ABI
 from manticore.core.smtlib import Operators, solver
 ETHER = 10**18

--- a/program-analysis/manticore/exercises/example/my_token.py
+++ b/program-analysis/manticore/exercises/example/my_token.py
@@ -1,6 +1,6 @@
 from manticore.utils import config
+consts = config.get_group("smt")
 # Either wait for Z3 
-# consts = config.get_group("smt")
 # consts.timeout = 99999
 # Or just shift to yikes ...
 consts.solver = consts.solver.yices

--- a/program-analysis/manticore/exercises/exercise1/solution.py
+++ b/program-analysis/manticore/exercises/exercise1/solution.py
@@ -1,12 +1,11 @@
 from manticore.ethereum import ManticoreEVM
 from manticore.ethereum.abi import ABI
 from manticore.core.smtlib import Operators
-
 ETHER = 10**18
 
 m = ManticoreEVM() # initiate the blockchain
 # Init
-user_account = m.create_account()
+user_account = m.create_account(balance=1*ETHER)
 with open('token.sol', 'r') as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)
 

--- a/program-analysis/manticore/exercises/exercise2/solution.py
+++ b/program-analysis/manticore/exercises/exercise2/solution.py
@@ -1,11 +1,12 @@
 from manticore.ethereum import ManticoreEVM
 from manticore.core.smtlib import Operators, solver
 from manticore.ethereum.abi import ABI
+ETHER = 10**18
 
 m = ManticoreEVM() # initiate the blockchain
 
 # Generate the accounts
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 with open('overflow.sol') as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)
 

--- a/program-analysis/manticore/exercises/exercise2/template.py
+++ b/program-analysis/manticore/exercises/exercise2/template.py
@@ -1,11 +1,12 @@
 from manticore.ethereum import ManticoreEVM
 from manticore.core.smtlib import Operators, solver
 from manticore.ethereum.abi import ABI
+ETHER = 10**18
 
 m = ManticoreEVM() # initiate the blockchain
 
 # Generate the accounts
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 with open('overflow.sol') as f:
     contract_account = m.solidity_create_contract(f, owner=user_account)
 

--- a/program-analysis/manticore/getting-throwing-paths.md
+++ b/program-analysis/manticore/getting-throwing-paths.md
@@ -69,13 +69,14 @@ m.generate_testcase(state, 'BugFound')
 
 ```python3
 from manticore.ethereum import ManticoreEVM
+ETHER = 10**18
 
 m = ManticoreEVM()
 
 with open('example.sol') as f:
     source_code = f.read()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 contract_account = m.solidity_create_contract(source_code, owner=user_account)
 
 symbolic_var = m.make_symbolic_value()

--- a/program-analysis/manticore/running-under-manticore.md
+++ b/program-analysis/manticore/running-under-manticore.md
@@ -89,10 +89,11 @@ from manticore.ethereum import ManticoreEVM
 m = ManticoreEVM()
 ```
 
-A non-contract account is created using [m.create_account](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.create_account):
+A non-contract account is created using [m.create_account](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.create_account). It must have enough balance to pay for the gas of transactions:
 
 ```python3
-user_account = m.create_account(balance=1000)
+ETHER = 10**18
+user_account = m.create_account(balance=1*ETHER)
 ```
 
 A Solidity contract can be deployed using [m.solidity_create_contract](https://manticore.readthedocs.io/en/latest/api.html#manticore.ethereum.ManticoreEVM.solidity_create_contract):
@@ -189,13 +190,14 @@ Putting all the previous steps together, we obtain:
 
 ```python3
 from manticore.ethereum import ManticoreEVM
+ETHER = 10**18
 
 m = ManticoreEVM()
 
 with open('example.sol') as f:
     source_code = f.read()
 
-user_account = m.create_account(balance=1000)
+user_account = m.create_account(balance=1*ETHER)
 contract_account = m.solidity_create_contract(source_code, owner=user_account)
 
 symbolic_var = m.make_symbolic_value()

--- a/program-analysis/manticore/scripts/gh_action_test.sh
+++ b/program-analysis/manticore/scripts/gh_action_test.sh
@@ -60,6 +60,10 @@ test_exercise(){
     cd ../..
 }
 
+#install Yices
+sudo add-apt-repository ppa:sri-csl/formal-methods
+sudo apt-get update
+sudo apt-get install yices2
 
 cd program-analysis/manticore
 pip install manticore[evm]


### PR DESCRIPTION
This PR adjusts the opening balance of the callers' accounts through the manticore examples here.

Unless otherwise configured, mcore makes the caller pay for gas for transactions. Mcore is now faithful by default with regard to balance and gas. Accounts must have enough balance to pay for gas. 
