### PR TITLE
Update Echidna to 1.6.0

### DIFF
--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -47,6 +47,6 @@ cd /home/training
 
 ### Binary
 
-[https://github.com/crytic/echidna/releases/tag/1.4.0.0](https://github.com/crytic/echidna/releases/tag/1.4.0.0)
+[https://github.com/crytic/echidna/releases/tag/v1.6.0](https://github.com/crytic/echidna/releases/tag/v1.6.0)
 
 solc 0.5.11 is recommended for the exercises.

--- a/program-analysis/echidna/scripts/gh_action_test.sh
+++ b/program-analysis/echidna/scripts/gh_action_test.sh
@@ -2,7 +2,7 @@
 
 
 install_echidna(){
-    pip install crytic-compile
+    pip install crytic-compile slither-analyzer
     wget https://github.com/crytic/echidna/releases/download/v1.6.0/echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
     tar -xvf echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
     sudo mv echidna-test /usr/bin/

--- a/program-analysis/echidna/scripts/gh_action_test.sh
+++ b/program-analysis/echidna/scripts/gh_action_test.sh
@@ -3,8 +3,8 @@
 
 install_echidna(){
     pip install crytic-compile
-    wget https://github.com/crytic/echidna/releases/download/v1.5.1/echidna-test-v1.5.1-Ubuntu-18.04.tar.gz
-    tar -xvf echidna-test-v1.5.1-Ubuntu-18.04.tar.gz
+    wget https://github.com/crytic/echidna/releases/download/v1.6.0/echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
+    tar -xvf echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
     sudo mv echidna-test /usr/bin/
 }
 


### PR DESCRIPTION
This small PR will update the Echidna version to use v1.6.0 in the tutorials as well as in the CI tests.