### PR TITLE
Update to Echidna 1.6.1

### DIFF
--- a/program-analysis/echidna/example/blacklistpushpop.yaml
+++ b/program-analysis/echidna/example/blacklistpushpop.yaml
@@ -1,3 +1,3 @@
 estimateGas: true
 filterBlacklist: true
-filterFunctions: ["pop", "clear"]
+filterFunctions: ["C.pop()", "C.clear()"]

--- a/program-analysis/echidna/example/filter.yaml
+++ b/program-analysis/echidna/example/filter.yaml
@@ -1,2 +1,2 @@
 filterBlacklist: true
-filterFunctions: ["reset1", "reset2"]
+filterFunctions: ["C.reset1()", "C.reset2()"]

--- a/program-analysis/echidna/filtering-functions.md
+++ b/program-analysis/echidna/filtering-functions.md
@@ -83,18 +83,18 @@ To blacklist functions, we can use this configuration file:
 
 ```yaml
 filterBlacklist: true
-filterFunctions: ["reset1", "reset2"]
+filterFunctions: ["C.reset1()", "C.reset2()"]
 ```
 
 Another approach to filter functions is to list the whitelisted functions. To do that, we can use this configuration file:
 
 ```yaml
 filterBlacklist: false
-filterFunctions: ["f", "g", "h", "i"]
+filterFunctions: ["C.f(uint256)", "C.g(uint256)", "C.h(uint256)", "C.i()"]
 ```
 
 - `filterBlacklist` is `true` by default.
-- Filtering will be performed by name only (without parameters). If you have `f()` and `f(uint256)`, the filter `"f"` will match both functions.
+- Filtering will be performed by full function name (contract name + "." + ABI). If you have `f()` and `f(uint256)`, you can specify exactly which function to filter.
 
 # Run Echidna
 
@@ -120,7 +120,7 @@ Echidna can either blacklist or whitelist functions to call during a fuzzing cam
 
 ```yaml
 filterBlacklist: true
-filterFunctions: ["f1", "f2", "f3"]
+filterFunctions: ["C.f1()", "C.f2()", "C.f3()"]
 ```
 
 ```bash
@@ -128,5 +128,5 @@ $ echidna-test contract.sol --config config.yaml
 ...
 ```
 
-Echidna starts a fuzzing campaign either blacklisting `f1`, `f2` and `f3` or only calling these, according
+Echidna starts a fuzzing campaign either blacklisting `C.f1()`, `C.f2()` and `C.f3()` or only calling these, according
 to the value of the `filterBlacklist` boolean.

--- a/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
+++ b/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
@@ -132,7 +132,7 @@ Blacklisting `pop` and `clear`, however, gives us much better results:
 
 ```yaml
 filterBlacklist: true
-filterFunctions: ["pop", "clear"]
+filterFunctions: ["C.pop()", "C.clear()"]
 ```
 
 ```

--- a/program-analysis/echidna/scripts/gh_action_test.sh
+++ b/program-analysis/echidna/scripts/gh_action_test.sh
@@ -3,8 +3,8 @@
 
 install_echidna(){
     pip install crytic-compile slither-analyzer
-    wget https://github.com/crytic/echidna/releases/download/v1.6.1/echidna-test-v1.6.1-Ubuntu-18.04.zip
-    unzip echidna-test-v1.6.1-Ubuntu-18.04.zip
+    wget https://github.com/crytic/echidna/releases/download/v1.6.1/echidna-test-1.6.1-Ubuntu-18.04.zip
+    unzip echidna-test-1.6.1-Ubuntu-18.04.zip
     tar -xf echidna-test.tar.gz
     sudo mv home/runner/.local/bin/echidna-test /usr/bin/
 }

--- a/program-analysis/echidna/scripts/gh_action_test.sh
+++ b/program-analysis/echidna/scripts/gh_action_test.sh
@@ -3,9 +3,10 @@
 
 install_echidna(){
     pip install crytic-compile slither-analyzer
-    wget https://github.com/crytic/echidna/releases/download/v1.6.0/echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
-    tar -xvf echidna-test-v1.6.0-Ubuntu-18.04.tar.gz
-    sudo mv echidna-test /usr/bin/
+    wget https://github.com/crytic/echidna/releases/download/v1.6.1/echidna-test-v1.6.1-Ubuntu-18.04.zip
+    unzip echidna-test-v1.6.1-Ubuntu-18.04.zip
+    tar -xf echidna-test.tar.gz
+    sudo mv home/runner/.local/bin/echidna-test /usr/bin/
 }
 
 test_example(){


### PR DESCRIPTION
This PR updates Echidna to the release 1.6.1, updating the function filter tutorial and examples. Manticore tests are failing, but they should be fixed in a different PR.