### PR TITLE
Tutorial on end-to-end testing with Echidna

### DIFF
--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -111,7 +111,7 @@ After etheno finishes, kill it using ctrl+c (twice). It will save the `init.json
 
 Once we have a json file with saved transactions, we can verify that the `SimpleStorage` contract is deployed in `0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c`, so we can easily write a contract (`./contracts/crytic/E2E.sol`) with a simple a property to test it:
 
-```
+```solidity
 import "../SimpleStorage.sol";
 
 contract E2E {
@@ -124,7 +124,7 @@ contract E2E {
 
 This simple property checks if the stored data remains constant. To run it you will need the following echidna config file (`echidna.yaml`):
 
-```
+```yaml
 prefix: crytic_
 initialize: init.json
 multi-abi: true

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -12,11 +12,19 @@ For this document, [we used the metacoin example](https://github.com/truffle-box
 
 Before doing anything, let's install the tools we need:
 
-* Install echidna from [dev-auto branch]().
+* Install echidna from [master branch]().
 * Install etheno from [X branch]().
 * Install slither from [dev-new-props branch]().
 
-Then, install the packages to compile the project. If ganache and ganache-cli are not installed, add them manually. For instance, running: 
+Then, install the packages to compile the project:
+
+```
+$ git clone https://github.com/truffle-box/metacoin-box
+$ cd metacoin-box
+$ npm i
+```
+
+If ganache and ganache-cli are not installed, add them manually. For instance, running: 
 
 ```
 $ npm i ganache ganache-cli 
@@ -28,8 +36,8 @@ or:
 $ yarn add ganache ganache-cli
 ```
 
-It is also important to select *one* test script from the tests. Ideally, this test will deploy all (or most) contracts, including mock/test ones. 
-For instance, here we have part of a test script that deploys and uses the metacoin contracts:
+It is also important to select *one* test script from the available tests. Ideally, this test will deploy all (or most) contracts, including mock/test ones. 
+For instance, here we have part of a test script that deploys and uses the metacoin contracts (`metacoin.js`):
 
 ```js
 const MetaCoin = artifacts.require("MetaCoin");
@@ -51,15 +59,17 @@ contract('MetaCoin', (accounts) => {
   ...
 ```
 
-**❗ Important detail**: if the test hardcodes the some date (or uses the current time), Echidna (or Manticore) could have issues reproducing the transactions. For instance, if you have something like this:
+**❗ Important detail**: when selecting a test, if it hardcodes some date (or uses the current time), Echidna (or Manticore) could have issues reproducing the transactions. For instance, if you have something like this:
 
-```
+```js
 const now = Math.floor((new Date()).getTime() / 1000);
 ```
 
 Then, it is necessary to change the `now` constant:
 
+```js
 const now = 1524785992; // This is the value used by echidna/manticore
+```
 
 Otherwise, Echidna will fail to replicate the contract deployment from the scripts.
 
@@ -67,10 +77,10 @@ Otherwise, Echidna will fail to replicate the contract deployment from the scrip
 
 Before starting to write interesting properties, it is necessary to to collect an etheno trace to replay it inside Echidna:
 
-Fist, start Etheno: 
+First, start Etheno: 
 
 ```
-$ etheno --ganache --ganache-args "--deterministic --gasLimit 10000000" -x output.json
+$ etheno --ganache --ganache-args "--deterministic --gasLimit 10000000" -x init.json
 ```
 
 In another terminal, run *one* test or the deployment process. How to run it depends on how the project was developed. For instance, for truffle, use:
@@ -98,14 +108,20 @@ module.exports = {
 };
 ```
 
-After etheno finishes, kill it using ctrl+c. It will save the `output.json` file.
+In the MetaCoin repository, we will run:
+
+```
+$ truffle test test/metacoin.js`.
+```
+
+After etheno finishes, kill it using ctrl+c (twice). It will save the `init.json` file.
 
 ## Writing properties:
 
-Once we have a json file with saved transactions, we can run slither-prop to generate a template of the properties to use. This tool is optional, but very recommended. It will also show useful information on each transaction, so we can copy where each contract was deployed.
+Once we have a json file with saved transactions, we can run `slither-prop` to generate a template of the properties to use. This tool is optional, but very recommended. It will also show useful information on each transaction, so we can know where and how each contract was deployed.
 
 ``` 
-$ slither-prop  . --txs output.json
+$ slither-prop  . --txs init.json
 ```
 
 This tool shows a list of transactions with some labels for each deployed/called contract. For instance:

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -16,7 +16,7 @@ For this tutorial, [we used the drizzle-box example](https://github.com/truffle-
 
 Before doing anything, let's install the tools we need:
 
-* Install echidna from [dev-refactor-etheno branch](https://github.com/crytic/echidna/pull/615).
+* Install echidna from [master branch](https://github.com/crytic/echidna).
 * Install etheno from [dev-ganache-improvements branch](https://github.com/crytic/etheno/tree/dev-ganache-improvements).
 
 

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -1,3 +1,7 @@
+# End-to-End testing with Echidna (Part I)
+
+When smart contracts require a complex initialization and the time to do it is short, we want to avoid to manually recreate a deployment for a fuzzing campaign with Echidna. That's why we have a new approach for testing using Echidna based on the deployments and execution of tests directly from ganache.
+
 ## Requirements:
 
 This approach needs a smart contract project, with the following constraints:
@@ -134,7 +138,7 @@ $ echidna-test . --contract E2E --config echidna.yaml
 ...
 crytic_const_storage: failed!💥  
   Call sequence:
-    set(0)
+    (0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c).set(0) from: 0x0000000000000000000000000000000000010000
 ```
 
-In the next part of this tutorial, we will explore how to easily find where contracts are deployed with a specific tool. This will be useful if the deployment process is complex and we need to test an specific contract.
+In the next part of this tutorial, we will explore how to easily find where contracts are deployed with a specific tool based on Slither. This will be useful if the deployment process is complex and we need to test an specific contract.

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -98,7 +98,7 @@ $ buidler test test/test.js --network localhost
 In the Drizzle example, we will run:
 
 ```
-$ truffle test test/simplestorage.js --network develop`.
+$ truffle test test/simplestorage.js --network develop.
 ```
 
 After etheno finishes, kill it using ctrl+c (twice). It will save the `init.json` file.
@@ -118,12 +118,19 @@ contract E2E {
 }
 ```
 
-This simple property checks if the stored data remains constant. To run it you will need this echidna config:
+This simple property checks if the stored data remains constant. To run it you will need the following echidna config file (`echidna.yaml`):
+
+```
+prefix: crytic_
+initialize: init.json
+multi-abi: true
+cryticArgs: ['--truffle-build-directory', 'app/src/contracts/'] # needed by drizzle
+```
 
 Then, running Echidna shows the results immediately: 
 
 ```
-$ echidna-test . --contract E2E --config echidna_config.yaml
+$ echidna-test . --contract E2E --config echidna.yaml
 ...
 crytic_const_storage: failed!💥  
   Call sequence:

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -6,22 +6,22 @@ This approach needs a smart contract project, with the following constraints:
 * It should have tests or at least, a complete deployment script. 
 * It should work with slither. If it fails, [please report the issue](https://github.com/crytic/slither).
 
-For this document, [we used the metacoin example](https://github.com/truffle-box/metacoin-box).
+For this tutorial, [we used the drizzle-box example](https://github.com/truffle-box/drizzle-box). 
 
 ## Getting started:
 
 Before doing anything, let's install the tools we need:
 
-* Install echidna from [master branch]().
-* Install etheno from [X branch]().
-* Install slither from [dev-new-props branch]().
+* Install echidna from [dev-refactor-etheno branch](https://github.com/crytic/echidna/pull/615).
+* Install etheno from [dev-ganache-improvements branch](https://github.com/crytic/etheno/tree/dev-ganache-improvements).
+
 
 Then, install the packages to compile the project:
 
 ```
-$ git clone https://github.com/truffle-box/metacoin-box
-$ cd metacoin-box
-$ npm i
+$ git clone https://github.com/truffle-box/drizzle-box
+$ cd drizzle-box
+$ npm i truffle
 ```
 
 If ganache and ganache-cli are not installed, add them manually. For instance, running: 
@@ -37,41 +37,41 @@ $ yarn add ganache ganache-cli
 ```
 
 It is also important to select *one* test script from the available tests. Ideally, this test will deploy all (or most) contracts, including mock/test ones. 
-For instance, here we have part of a test script that deploys and uses the metacoin contracts (`metacoin.js`):
+Let's take a look to `SimpleStorage`, one of the contracts:
+
+```solidity
+contract SimpleStorage {
+    event StorageSet(string _message);
+
+    uint256 public storedData;
+
+    function set(uint256 x) public {
+        storedData = x;
+
+        emit StorageSet("Data stored successfully!");
+    }
+}
+```
+
+This small contract allows to set the `storedData` state variable. As expected, we have a unit test that deploys and tests this contract (`simplestorage.js`):
 
 ```js
-const MetaCoin = artifacts.require("MetaCoin");
+const SimpleStorage = artifacts.require("SimpleStorage");
 
-contract('MetaCoin', (accounts) => {
-  it('should put 10000 MetaCoin in the first account', async () => {
-    const metaCoinInstance = await MetaCoin.deployed();
-    const balance = await metaCoinInstance.getBalance.call(accounts[0]);
+contract("SimpleStorage", accounts => {
+  it("...should store the value 89.", async () => {
+    const simpleStorageInstance = await SimpleStorage.deployed();
 
-    assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
+    // Set value of 89
+    await simpleStorageInstance.set(89, { from: accounts[0] });
+
+    // Get stored value
+    const storedData = await simpleStorageInstance.storedData.call();
+
+    assert.equal(storedData, 89, "The value 89 was not stored.");
   });
-  it('should call a function that depends on a linked library', async () => {
-    const metaCoinInstance = await MetaCoin.deployed();
-    const metaCoinBalance = (await metaCoinInstance.getBalance.call(accounts[0])).toNumber();
-    const metaCoinEthBalance = (await metaCoinInstance.getBalanceInEth.call(accounts[0])).toNumber();
-
-    assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, 'Library function returned unexpected function, linkage may be broken');
-  });
-  ...
+});
 ```
-
-**❗ Important detail**: when selecting a test, if it hardcodes some date (or uses the current time), Echidna (or Manticore) could have issues reproducing the transactions. For instance, if you have something like this:
-
-```js
-const now = Math.floor((new Date()).getTime() / 1000);
-```
-
-Then, it is necessary to change the `now` constant:
-
-```js
-const now = 1524785992; // This is the value used by echidna/manticore
-```
-
-Otherwise, Echidna will fail to replicate the contract deployment from the scripts.
 
 ## Capturing transactions
 
@@ -95,81 +95,39 @@ for buidler:
 $ buidler test test/test.js --network localhost
 ```
 
-When using MetaCoin, we will need to modify the `truffle-config.json` file to look like this:
-```js
-module.exports = {
-  networks: {
-    development: {
-      host: "127.0.0.1",
-      port: 8545,
-      network_id: "*"
-   }
-  }
-};
-```
-
-In the MetaCoin repository, we will run:
+In the Drizzle example, we will run:
 
 ```
-$ truffle test test/metacoin.js`.
+$ truffle test test/simplestorage.js --network develop`.
 ```
 
 After etheno finishes, kill it using ctrl+c (twice). It will save the `init.json` file.
 
-## Writing properties:
+## Writing and running a property:
 
-Once we have a json file with saved transactions, we can run `slither-prop` to generate a template of the properties to use. This tool is optional, but very recommended. It will also show useful information on each transaction, so we can know where and how each contract was deployed.
-
-``` 
-$ slither-prop  . --txs init.json
-```
-
-This tool shows a list of transactions with some labels for each deployed/called contract. For instance:
+Once we have a json file with saved transactions, we can verify that the `SimpleStorage` contract is deployed in `0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c`, so we can easily write a contract (`./contracts/crytic/E2E.sol`) with a simple a property to test it:
 
 ```
-List of transactions:
-DEPLOYED Migrations at 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
-0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
-DEPLOYED ConvertLib at 0x9f54ce775a110c27761b78e6a684b95f13717292
-CREATE at 0x312883951fc1724ef95667f67768691fe5d99d8b
-0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
-0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called sendCoin(address,uint256) in 0x312883951fc1724ef95667f67768691fe5d99d8b
-Found the following accounts: 0x6e27e32c5daacc590efb7cd3ad6232b60333ef59
-Write contracts/crytic/interfaces.sol
-Write contracts/crytic/PropertiesAUTO.sol
-Write contracts/crytic/TestAUTO.sol
-Write echidna_config.yaml
-To run Echidna:
-	 echidna-test . --contract TestAUTO --config echidna_config.yaml 
-```
+import "../SimpleStorage.sol";
 
-For instance, if we are going to add a property about MetaCoin, we should use 0x312883951fc1724ef95667f67768691fe5d99d8b in the PropertiesAUTO contract (it's the contract that the test uses when calling sendCoin). 
-
-```solidity
-contract PropertiesAUTO is CryticInterface{
-
-        MetaCoin mc = MetaCoin(0x312883951Fc1724EF95667F67768691FE5D99d8B);
-        function crytic_self_send() public returns(bool) {
-                // property here
+contract E2E {
+        SimpleStorage st = SimpleStorage(0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c);
+        function crytic_const_storage() public returns(bool) {
+            return st.storedData() == 89;
         }
-
 }
 ```
 
-All the properties should be written from an external perspective. If you cannot write a property because some variables are not public/external, that's probably an issue, since users will not be able to know exactly what is going on inside the contract. 
+This simple property checks if the stored data remains constant. To run it you will need this echidna config:
 
-Additionally, `slither-prop` provides the list of addresses used during the deployment. It is important to pay attention to them, since these could be useful to add into the echidna. For instance:
+Then, running Echidna shows the results immediately: 
 
 ```
-0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
-0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called sendCoin(address,uint256) in 0x312883951fc1724ef95667f67768691fe5d99d8b
-Found the following accounts: 0x6e27e32c5daacc590efb7cd3ad6232b60333ef59
-… 
+$ echidna-test . --contract E2E --config echidna_config.yaml
+...
+crytic_const_storage: failed!💥  
+  Call sequence:
+    set(0)
 ```
 
-The first line shows the addresses from accounts[0] as we saw them in the testing script. It is a good idea to include these addresses in the echidna config, to allow our tool to generate transactions from them:
-
-```yaml
-sender: ['0x6e27e32c5daacc590efb7cd3ad6232b60333ef59']
-psender: '0x6e27e32c5daacc590efb7cd3ad6232b60333ef59'
-```
+In the next part of this tutorial, we will explore how to easily find where contracts are deployed with a specific tool. This will be useful if the deployment process is complex and we need to test an specific contract.

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -1,0 +1,159 @@
+## Requirements:
+
+This approach needs a smart contract project, with the following constraints:
+
+* It should use Solidity: Vyper is not supported, since Slither/Echidna is not very effective running these (e.g. no AST is included). 
+* It should have tests or at least, a complete deployment script. 
+* It should work with slither. If it fails, [please report the issue](https://github.com/crytic/slither).
+
+For this document, [we used the metacoin example](https://github.com/truffle-box/metacoin-box).
+
+## Getting started:
+
+Before doing anything, let's install the tools we need:
+
+* Install echidna from [dev-auto branch]().
+* Install etheno from [X branch]().
+* Install slither from [dev-new-props branch]().
+
+Then, install the packages to compile the project. If ganache and ganache-cli are not installed, add them manually. For instance, running: 
+
+```
+$ npm i ganache ganache-cli 
+```
+
+or:
+
+```
+$ yarn add ganache ganache-cli
+```
+
+It is also important to select *one* test script from the tests. Ideally, this test will deploy all (or most) contracts, including mock/test ones. 
+For instance, here we have part of a test script that deploys and uses the metacoin contracts:
+
+```js
+const MetaCoin = artifacts.require("MetaCoin");
+
+contract('MetaCoin', (accounts) => {
+  it('should put 10000 MetaCoin in the first account', async () => {
+    const metaCoinInstance = await MetaCoin.deployed();
+    const balance = await metaCoinInstance.getBalance.call(accounts[0]);
+
+    assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
+  });
+  it('should call a function that depends on a linked library', async () => {
+    const metaCoinInstance = await MetaCoin.deployed();
+    const metaCoinBalance = (await metaCoinInstance.getBalance.call(accounts[0])).toNumber();
+    const metaCoinEthBalance = (await metaCoinInstance.getBalanceInEth.call(accounts[0])).toNumber();
+
+    assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, 'Library function returned unexpected function, linkage may be broken');
+  });
+  ...
+```
+
+**❗ Important detail**: if the test hardcodes the some date (or uses the current time), Echidna (or Manticore) could have issues reproducing the transactions. For instance, if you have something like this:
+
+```
+const now = Math.floor((new Date()).getTime() / 1000);
+```
+
+Then, it is necessary to change the `now` constant:
+
+const now = 1524785992; // This is the value used by echidna/manticore
+
+Otherwise, Echidna will fail to replicate the contract deployment from the scripts.
+
+## Capturing transactions
+
+Before starting to write interesting properties, it is necessary to to collect an etheno trace to replay it inside Echidna:
+
+Fist, start Etheno: 
+
+```
+$ etheno --ganache --ganache-args "--deterministic --gasLimit 10000000" -x output.json
+```
+
+In another terminal, run *one* test or the deployment process. How to run it depends on how the project was developed. For instance, for truffle, use:
+
+```
+$ truffle test test/test.js
+```
+
+for buidler:
+
+```
+$ buidler test test/test.js --network localhost
+```
+
+When using MetaCoin, we will need to modify the `truffle-config.json` file to look like this:
+```js
+module.exports = {
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*"
+   }
+  }
+};
+```
+
+After etheno finishes, kill it using ctrl+c. It will save the `output.json` file.
+
+## Writing properties:
+
+Once we have a json file with saved transactions, we can run slither-prop to generate a template of the properties to use. This tool is optional, but very recommended. It will also show useful information on each transaction, so we can copy where each contract was deployed.
+
+``` 
+$ slither-prop  . --txs output.json
+```
+
+This tool shows a list of transactions with some labels for each deployed/called contract. For instance:
+
+```
+List of transactions:
+DEPLOYED Migrations at 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
+0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
+DEPLOYED ConvertLib at 0x9f54ce775a110c27761b78e6a684b95f13717292
+CREATE at 0x312883951fc1724ef95667f67768691fe5d99d8b
+0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
+0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called sendCoin(address,uint256) in 0x312883951fc1724ef95667f67768691fe5d99d8b
+Found the following accounts: 0x6e27e32c5daacc590efb7cd3ad6232b60333ef59
+Write contracts/crytic/interfaces.sol
+Write contracts/crytic/PropertiesAUTO.sol
+Write contracts/crytic/TestAUTO.sol
+Write echidna_config.yaml
+To run Echidna:
+	 echidna-test . --contract TestAUTO --config echidna_config.yaml 
+```
+
+For instance, if we are going to add a property about MetaCoin, we should use 0x312883951fc1724ef95667f67768691fe5d99d8b in the PropertiesAUTO contract (it's the contract that the test uses when calling sendCoin). 
+
+```solidity
+contract PropertiesAUTO is CryticInterface{
+
+        MetaCoin mc = MetaCoin(0x312883951Fc1724EF95667F67768691FE5D99d8B);
+        function crytic_self_send() public returns(bool) {
+                // property here
+        }
+
+}
+```
+
+All the properties should be written from an external perspective. If you cannot write a property because some variables are not public/external, that's probably an issue, since users will not be able to know exactly what is going on inside the contract. 
+
+Additionally, `slither-prop` provides the list of addresses used during the deployment. It is important to pay attention to them, since these could be useful to add into the echidna. For instance:
+
+```
+0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called setCompleted(uint256) in 0x946135c05cfc5e7c6d0f8259e12c53aa26a4f63e
+0x6e27e32c5daacc590efb7cd3ad6232b60333ef59 called sendCoin(address,uint256) in 0x312883951fc1724ef95667f67768691fe5d99d8b
+Found the following accounts: 0x6e27e32c5daacc590efb7cd3ad6232b60333ef59
+… 
+```
+
+The first line shows the addresses from accounts[0] as we saw them in the testing script. It is a good idea to include these addresses in the echidna config, to allow our tool to generate transactions from them:
+
+```yaml
+sender: ['0x6e27e32c5daacc590efb7cd3ad6232b60333ef59']
+psender: '0x6e27e32c5daacc590efb7cd3ad6232b60333ef59'
+```


### PR DESCRIPTION
This tutorial presents a new approach to use Echidna called end-to-end testing (a.k.a. E2E). It uses a simple truffle box called drizzle, which is absolutely basic in terms of code, since metacoin required to know exactly how libraries are deployed and there is still a gap for that in our tooling. It it worth mentioning that this is the first iteration and the required branches and the UI will improve in the near future.