### PR TITLE
Disable fail-fast on GH Actions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   tests:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         type: ["slither", "echidna", "manticore"]
     steps:


### PR DESCRIPTION
By disabling fail-fast, all three jobs are run completely, instead of
being cancelled mid-execution if one of them fails.