### PR TITLE
Fix manticore tests in CI

### DIFF
--- a/program-analysis/manticore/scripts/gh_action_test.sh
+++ b/program-analysis/manticore/scripts/gh_action_test.sh
@@ -62,7 +62,7 @@ test_exercise(){
 
 
 
-pip install manticore
+pip install manticore==0.3.5
 
 cd program-analysis/manticore
 

--- a/program-analysis/manticore/scripts/gh_action_test.sh
+++ b/program-analysis/manticore/scripts/gh_action_test.sh
@@ -62,7 +62,7 @@ test_exercise(){
 
 
 
-pip install manticore==0.3.5
+pip install manticore==0.3.5 crytic-compile==0.1.13
 
 cd program-analysis/manticore
 


### PR DESCRIPTION
The code has not been adapted to the newer Manticore and crytic-compile releases yet,
so this pins the dependencies to the last working versions until the
tests can be updated.