### PR TITLE
Pr/84

### DIFF
--- a/program-analysis/echidna/Exercise-1.md
+++ b/program-analysis/echidna/Exercise-1.md
@@ -62,12 +62,13 @@ The skeleton for this exercise is (*[exercises/exercise1/template.sol](./exercis
 ```Solidity
      import "token.sol";
      contract TestToken is Token {
-       address echidna_caller = 0x00a329c0648769a73afac7f9381e08fb43dbea70;
+       address echidna_caller = msg.sender;
 
         constructor() public{
             balances[echidna_caller] = 10000;
          }
          // add the property
+        function echidna_test_balance() public view returns (bool) {}
       }
  ```
 

--- a/program-analysis/echidna/Exercise-2.md
+++ b/program-analysis/echidna/Exercise-2.md
@@ -71,7 +71,7 @@ The skeleton for this exercise is (*[exercises/exercise2/template.sol](./exercis
          owner = 0x0; // lose ownership
        }
       // add the property
-      function echidna_cannot_be_unpaused() public view returns (bool) {}
+      function echidna_no_transfer() public view returns (bool) {}
    }
 ```
 

--- a/program-analysis/echidna/Exercise-2.md
+++ b/program-analysis/echidna/Exercise-2.md
@@ -58,20 +58,21 @@ We will test the following contract *[exercises/exercise2/token.sol](./exercises
 
 - Consider `paused()` to be called at deployment, and the ownership removed.
 - Add a property to check that the contract cannot be unpaused.
-- Once Echidna found the bug, fix the issue, and re-try your property with Echidna.
+- Once Echidna finds the bug, fix the issue, and re-try your property with Echidna.
 
 The skeleton for this exercise is (*[exercises/exercise2/template.sol](./exercises/exercise2/template.sol)*):
 
 ```Solidity
    import "token.sol";
    contract TestToken is Token {
-      address echidna_caller = 0x00a329c0648769a73afac7f9381e08fb43dbea70;
+      address echidna_caller = msg.sender;
       constructor(){
          paused(); // pause the contract
          owner = 0x0; // lose ownership
        }
          // add the property
-     }
+      function echidna_cannot_be_unpaused() public view returns (bool) {}
+   }
 ```
 
 ## Solution

--- a/program-analysis/echidna/Exercise-2.md
+++ b/program-analysis/echidna/Exercise-2.md
@@ -70,7 +70,7 @@ The skeleton for this exercise is (*[exercises/exercise2/template.sol](./exercis
          paused(); // pause the contract
          owner = 0x0; // lose ownership
        }
-         // add the property
+      // add the property
       function echidna_cannot_be_unpaused() public view returns (bool) {}
    }
 ```

--- a/program-analysis/echidna/Exercise-3.md
+++ b/program-analysis/echidna/Exercise-3.md
@@ -94,7 +94,7 @@ The skeleton for this exercise is (*[exercises/exercise3/template.sol](./exercis
       constructor() public {}
 
       // add the property
-      function echidna_cannot_mint_more() public view returns (bool) {}
+      function echidna_test_balance() public view returns (bool) {}
    }
 ```
 

--- a/program-analysis/echidna/Exercise-3.md
+++ b/program-analysis/echidna/Exercise-3.md
@@ -1,6 +1,6 @@
 # Exercise 3
 
-This exercise requires to finish the [exercise 1](./Exercise-1.md) and the [exercise 2](./Exercise-2.md)
+This exercise requires to finish [exercise 1](./Exercise-1.md) and [exercise 2](./Exercise-2.md)
 
 **Table of contents:**
 
@@ -17,9 +17,9 @@ We will test the following contract *[exercises/exercise3/token.sol](./exercises
 ```Solidity
  contract Ownership{
     address owner = msg.sender;
-    function Owner(){
+    constructor() public {
         owner = msg.sender;
-     }
+    }
      modifier isOwner(){
          require(owner == msg.sender);
          _;
@@ -45,8 +45,9 @@ We will test the following contract *[exercises/exercise3/token.sol](./exercises
    contract Token is Pausable{
       mapping(address => uint) public balances;
       function transfer(address to, uint value) ifNotPaused public{
-           balances[msg.sender] -= value;
-           balances[to] += value;
+            require(balances[msg.sender] >= value);
+            balances[msg.sender] -= value;
+            balances[to] += value;
        }
     }
 
@@ -78,9 +79,24 @@ The [version of token.sol](./exercises/exercise3/token.sol#L1) contains the fixe
 
 ### Goals
 
-- Create a scenario, where `echidna_caller (0x00a329c0648769a73afac7f9381e08fb43dbea70)` becomes the owner of the contract at construction, and `totalMintable` is set to 10,000. Recall that Echidna needs a constructor without argument.
-- Add a property to check if `echidna_caller` cannot mint more than 10,000 tokens.
-- Once Echidna found the bug, fix the issue, and re-try your property with Echidna.
+- Create a scenario, where `echidna_caller (msg.sender)` becomes the owner of the contract at construction, and `totalMintable` is set to 10,000. Recall that Echidna needs a constructor without argument.
+- Add a property to check if `echidna_caller` can mint more than 10,000 tokens.
+- Once Echidna finds the bug, fix the issue, and re-try your property with Echidna.
+
+The skeleton for this exercise is (*[exercises/exercise3/template.sol](./exercises/exercise3/template.sol)*):
+
+```Solidity
+   import "mintable.sol";
+   contract TestToken is MintableToken {
+      address echidna_caller = msg.sender;
+
+      // update the constructor
+      constructor() public {}
+
+      // add the property
+      function echidna_cannot_mint_more() public view returns (bool) {}
+   }
+```
 
 ## Solution
 

--- a/program-analysis/echidna/Exercise-4.md
+++ b/program-analysis/echidna/Exercise-4.md
@@ -61,7 +61,7 @@ Add asserts to ensure that after calling `transfer`:
 - `msg.sender` must have its initial balance or less.
 - `to` must have its initial balance or more.
 
-Once Echidna found the bug, fix the issue, and re-try your assertion with Echidna.
+Once Echidna finds the bug, fix the issue, and re-try your assertion with Echidna.
 
 This exercise is similar to the [first one](Exercise-1.md), but using assertions instead of explicit properties.  
 However, in this exercise, it is easier to modify the original token contract (*[exercises/exercise4/token.sol](./exercises/exercise4/token.sol)*).

--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -2,7 +2,7 @@
 
 The aim of this tutorial is to show how to use Echidna to automatically test smart contracts.
 
-The first part introduces how to write a properties for Echidna.
+The first part introduces how to write properties for Echidna.
 The second part is a set of exercises to solve.
 
 **Table of contents:**

--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -2,7 +2,7 @@
 
 The aim of this tutorial is to show how to use Echidna to automatically test smart contracts.
 
-The first part introduces how to write a property for Echidna.
+The first part introduces how to write a properties for Echidna.
 The second part is a set of exercises to solve.
 
 **Table of contents:**
@@ -14,17 +14,17 @@ The second part is a set of exercises to solve.
 - Basic
   - [How to filter functions](./filtering-functions.md): How to filters the functions to be fuzzed
   - [How to test assertions](./assertion-checking.md): How to test assertions with Echidna
-  - [How to write good properties step by step](./property-creation.md): How to write properties iteratively where we improve them at each step
+  - [How to write good properties step by step](./property-creation.md): How to iteratively improve property testing
 - Advanced
   - [How to collect a corpus](./collecting-a-corpus.md): How to use Echidna to collect a corpus of transactions
   - [How to detect high gas consumption](./finding-transactions-with-high-gas-consumption.md): How to find functions with high gas consumption.
-  - [How to perform smart contract fuzzing at a large scale](./smart-contract-fuzzing-at-scale.md): How to use Echidna to run long fuzzing campaign in complex smart contracts.
-  - [How to test a library](https://blog.trailofbits.com/2020/08/17/using-echidna-to-test-a-smart-contract-library/): How Echidna was used to test the a library in Set Protocol (blogpost)
-  - [How to test bytecode-only contracts](./testing-bytecode.md): How to fuzz a contracts without bytecode, or to perform differential fuzzing between Solidity and Vyper
+  - [How to perform smart contract fuzzing at a large scale](./smart-contract-fuzzing-at-scale.md): How to use Echidna to run a long fuzzing campaign for complex smart contracts.
+  - [How to test a library](https://blog.trailofbits.com/2020/08/17/using-echidna-to-test-a-smart-contract-library/): How Echidna was used to test the library in Set Protocol (blogpost)
+  - [How to test bytecode-only contracts](./testing-bytecode.md): How to fuzz a contract without bytecode or to perform differential fuzzing between Solidity and Vyper
   - [How to seed Echidna with unit tests](./end-to-end-testing.md): How to use existing unit tests to seed Echidna
   - [Fuzzing tips](./fuzzing_tips.md): General fuzzing tips
 - Exercises
-  - [Exercise 1](./Exercise-1.md): Testing token's balance
+  - [Exercise 1](./Exercise-1.md): Testing token balances
   - [Exercise 2](./Exercise-2.md): Testing access control
   - [Exercise 3](./Exercise-3.md): Testing with custom initialization
   - [Exercise 4](./Exercise-4.md): Testing with `assert`
@@ -42,7 +42,7 @@ docker pull trailofbits/eth-security-toolbox
 docker run -it -v "$PWD":/home/training trailofbits/eth-security-toolbox
 ```
 
-*The last command runs eth-security-toolbox in a docker that has access to your current directory. You can change the files from your host, and run the tools on the files from the docker*
+*The last command runs eth-security-toolbox in a docker container that has access to your current directory. You can change the files from your host and run the tools on the files through the container*
 
 Inside docker, run :
 

--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -14,7 +14,7 @@ The second part is a set of exercises to solve.
 - Basic
   - [How to filter functions](./filtering-functions.md): How to filters the functions to be fuzzed
   - [How to test assertions](./assertion-checking.md): How to test assertions with Echidna
-  - [How to write good properties step by step](./property-creation.md): How to write properties in an iteratively process where we improved them at each step
+  - [How to write good properties step by step](./property-creation.md): How to write properties iteratively where we improve them at each step
 - Advanced
   - [How to collect a corpus](./collecting-a-corpus.md): How to use Echidna to collect a corpus of transactions
   - [How to detect high gas consumption](./finding-transactions-with-high-gas-consumption.md): How to find functions with high gas consumption.

--- a/program-analysis/echidna/assertion-checking.md
+++ b/program-analysis/echidna/assertion-checking.md
@@ -63,18 +63,18 @@ contract Incrementor {
 
 ## Run Echidna
 
-To enable the assertion failure testing in Echidna, create an [Echidna configuration file](https://github.com/crytic/echidna/wiki/Config), `config.yaml`, with `testMode` set for assertion checking:
+To enable the assertion failure testing in Echidna, you can use `--test-mode assertion` directly from the command line. 
+
+Otherwise, you can create an [Echidna configuration file](https://github.com/crytic/echidna/wiki/Config), `config.yaml`, with `testMode` set for assertion checking:
 
 ```yaml
 testMode: assertion
 ```
 
-Otherwise, you can use `--test-mode assertion` directly from the command line.
-
 When we run this contract in Echidna, we obtain the expected results:
 
 ```
-$ echidna-test assert.sol --config config.yaml 
+$ echidna-test assert.sol --test-mode assertion
 Analyzing contract: assert.sol:Incrementor
 assertion in inc: failed!💥  
   Call sequence, shrinking (2596/5000):
@@ -87,7 +87,7 @@ Seed: 1806480648350826486
 
 As you can see, Echidna reports an assertion failure in the `inc` function. Adding more than one assertion per function is possible, however, Echidna cannot tell which assertion failed.
 
-## When and how use assertions
+## When and how to use assertions
 
 Assertions can be used as alternatives to explicit properties if the conditions to check are directly related to the correct use of some operation `f`. Adding assertions after some code will enforce that the check will happen immediately after it was executed: 
 
@@ -141,7 +141,7 @@ contract Incrementor {
 ```
 
 ```bash
-$ echidna-test assert.sol --config config.yaml 
+$ echidna-test assert.sol --test-mode assertion
 Analyzing contract: assert.sol:Incrementor
 assertion in inc: failed!💥  
   Call sequence, shrinking (2596/5000):

--- a/program-analysis/echidna/assertion-checking.md
+++ b/program-analysis/echidna/assertion-checking.md
@@ -29,7 +29,7 @@ contract Incrementor {
 }
 ```
 
-We want to make sure that `tmp` is less or equal than `counter` after returning its difference. We could write an Echidna property, but we will need to store the `tmp` value somewhere. Instead, we could use an assertion like this one:
+We want to make sure that `tmp` is less than or equal to `counter` after returning its difference. We could write an Echidna property, but we will need to store the `tmp` value somewhere. Instead, we could use an assertion like this one (*[example/assert.sol](./example/assert.sol)*):
 
 ```solidity
 contract Incrementor {

--- a/program-analysis/echidna/assertion-checking.md
+++ b/program-analysis/echidna/assertion-checking.md
@@ -71,7 +71,7 @@ Otherwise, you can create an [Echidna configuration file](https://github.com/cry
 testMode: assertion
 ```
 
-When we run this contract in Echidna, we obtain the expected results:
+When we run this contract with Echidna, we obtain the expected results:
 
 ```
 $ echidna-test assert.sol --test-mode assertion
@@ -89,7 +89,7 @@ As you can see, Echidna reports an assertion failure in the `inc` function. Addi
 
 ## When and how to use assertions
 
-Assertions can be used as alternatives to explicit properties if the conditions to check are directly related to the correct use of some operation `f`. Adding assertions after some code will enforce that the check will happen immediately after it was executed: 
+Assertions can be used as alternatives to explicit properties if the conditions to check are directly related to the correct use of some operation `f`. Adding assertions after some code will enforce that the check happens immediately after it was executed: 
 
 ```solidity
 function f(..) public {

--- a/program-analysis/echidna/collecting-a-corpus.md
+++ b/program-analysis/echidna/collecting-a-corpus.md
@@ -167,7 +167,7 @@ Seed: -7293830866560616537
 
 ```
 
-This time, the property is violated immediately. We can verify that another `covered.*.txt` file is created showing another trace (labeled with `*`) that Echidna executed that finished with a return at the end of the `magic` function.
+This time, the property is violated immediately. We can verify that another `covered.*.txt` file is created showing another trace (labeled with `*`) that Echidna executed which finished with a return at the end of the `magic` function.
 
 ```
 *r  |contract C {

--- a/program-analysis/echidna/collecting-a-corpus.md
+++ b/program-analysis/echidna/collecting-a-corpus.md
@@ -84,9 +84,9 @@ r   |    require(magic_3 == magic_4+333);
 ```
 
 The label `r` on the left of each line shows that Echidna is able to reach these lines but it ends in a revert. 
-As you can see, the fuzzer gets stuck in the last `require`.
+As you can see, the fuzzer gets stuck at the last `require`.
 
-To find a workaround, let's take look to the corpus it collected. For instance, one of these files was:
+To find a workaround, let's take a look at the corpus it collected. For instance, one of these files was:
 
 ```json
 [
@@ -140,7 +140,7 @@ To find a workaround, let's take look to the corpus it collected. For instance, 
 ]
 ```
 
-Clearly, this input will not trigger the failure in our property. However, in the next step, we will see how to modify it for that.
+Clearly, this input will not trigger the failure in our property. In the next step, we will see how to modify it for that.
 
 ## Seeding a corpus
 
@@ -148,7 +148,7 @@ Echidna needs some help in order to deal with the `magic` function. We are going
 parameters for it:
 
 ```
-$ cp corpus-magic/coverage/2712688662897926208.txt corpus-magic/coverage/new.txt
+$ cp corpus-magic/coverage/covered.*.txt corpus-magic/coverage/new.txt
 ```
 
 We will modify `new.txt` to call `magic(42,129,333,0)`. Now, we can re-run Echidna:
@@ -167,7 +167,7 @@ Seed: -7293830866560616537
 
 ```
 
-This time, the property is violated inmmediately. We can verify that another `covered.*.txt` file is created showing another trace (labeled with `*`) that Echidna executed that finished with a return at the end of the `magic` function.
+This time, the property is violated immediately. We can verify that another `covered.*.txt` file is created showing another trace (labeled with `*`) that Echidna executed that finished with a return at the end of the `magic` function.
 
 ```
 *r  |contract C {

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -1,6 +1,6 @@
 # End-to-End testing with Echidna (Part I)
 
-When smart contracts require a complex initialization and the time to do it is short, we want to avoid to manually recreate a deployment for a fuzzing campaign with Echidna. That's why we have a new approach for testing using Echidna based on the deployments and execution of tests directly from ganache.
+When smart contracts require a complex initialization and the time to do it is short, we want to avoid to manually recreating a deployment for a fuzzing campaign with Echidna. That's why we have a new approach for testing using Echidna based on the deployments and execution of tests directly from ganache.
 
 ## Requirements:
 

--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -1,14 +1,14 @@
 # End-to-End testing with Echidna (Part I)
 
-When smart contracts require a complex initialization and the time to do it is short, we want to avoid to manually recreating a deployment for a fuzzing campaign with Echidna. That's why we have a new approach for testing using Echidna based on the deployments and execution of tests directly from ganache.
+When smart contracts require a complex initialization and the time to do it is short, we want to avoid manually recreating a deployment for a fuzzing campaign with Echidna. That's why we have a new approach for testing using Echidna based on the deployments and execution of tests directly from ganache.
 
 ## Requirements:
 
 This approach needs a smart contract project, with the following constraints:
 
-* It should use Solidity: Vyper is not supported, since Slither/Echidna is not very effective running these (e.g. no AST is included). 
+* It should use Solidity: Vyper is not supported, since Slither/Echidna is not very effective at running these (e.g. no AST is included). 
 * It should have tests or at least, a complete deployment script. 
-* It should work with slither. If it fails, [please report the issue](https://github.com/crytic/slither).
+* It should work with Slither. If it fails, [please report the issue](https://github.com/crytic/slither).
 
 For this tutorial, [we used the drizzle-box example](https://github.com/truffle-box/drizzle-box). 
 
@@ -16,8 +16,8 @@ For this tutorial, [we used the drizzle-box example](https://github.com/truffle-
 
 Before doing anything, let's install the tools we need:
 
-* Install echidna from [master branch](https://github.com/crytic/echidna).
-* Install etheno from [dev-ganache-improvements branch](https://github.com/crytic/etheno/tree/dev-ganache-improvements).
+* Install Echidna from [master branch](https://github.com/crytic/echidna).
+* Install Etheno from [dev-ganache-improvements branch](https://github.com/crytic/etheno/tree/dev-ganache-improvements).
 
 
 Then, install the packages to compile the project:
@@ -79,7 +79,7 @@ contract("SimpleStorage", accounts => {
 
 ## Capturing transactions
 
-Before starting to write interesting properties, it is necessary to to collect an etheno trace to replay it inside Echidna:
+Before starting to write interesting properties, it is necessary to to collect an Etheno trace to replay it inside Echidna:
 
 First, start Etheno: 
 
@@ -105,11 +105,11 @@ In the Drizzle example, we will run:
 $ truffle test test/simplestorage.js --network develop.
 ```
 
-After etheno finishes, kill it using ctrl+c (twice). It will save the `init.json` file.
+After Etheno finishes, kill it using ctrl+c (twice). It will save the `init.json` file.
 
 ## Writing and running a property:
 
-Once we have a json file with saved transactions, we can verify that the `SimpleStorage` contract is deployed in `0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c`, so we can easily write a contract (`./contracts/crytic/E2E.sol`) with a simple a property to test it:
+Once we have a json file with saved transactions, we can verify that the `SimpleStorage` contract is deployed at `0x871DD7C2B4b25E1Aa18728e9D5f2Af4C4e431f5c`, so we can easily write a contract (`./contracts/crytic/E2E.sol`) with a simple a property to test it:
 
 ```solidity
 import "../SimpleStorage.sol";

--- a/program-analysis/echidna/exercises/exercise1/solution.sol
+++ b/program-analysis/echidna/exercises/exercise1/solution.sol
@@ -1,16 +1,15 @@
 import "token.sol";
 
+/// @dev to run: $ echidna-test solution.sol
 contract TestToken is Token {
+    address echidna_caller = msg.sender;
 
-    address echidna_caller = 0x00a329C0648769a73afAC7F9381e08fb43DBEA70;
-
-    constructor() public{
+    constructor() public {
         balances[echidna_caller] = 10000;
     }
 
     // add the property
-    function echidna_test_balance() view public returns(bool){
+    function echidna_test_balance() public view returns (bool) {
         return balances[echidna_caller] <= 10000;
-    }   
-
+    }
 }

--- a/program-analysis/echidna/exercises/exercise2/solution.sol
+++ b/program-analysis/echidna/exercises/exercise2/solution.sol
@@ -1,16 +1,14 @@
 import "token.sol";
 
+/// @dev to run: $ echidna-test solution.sol
 contract TestToken is Token {
-
     constructor() public {
         paused();
         owner = address(0x0); // lose ownership
     }
 
     // add the property
-    function echidna_no_transfer() public view returns(bool){
+    function echidna_no_transfer() public view returns (bool) {
         return is_paused == true;
-    }   
-
+    }
 }
-

--- a/program-analysis/echidna/exercises/exercise2/solution.sol
+++ b/program-analysis/echidna/exercises/exercise2/solution.sol
@@ -8,7 +8,7 @@ contract TestToken is Token {
     }
 
     // add the property
-    function echidna_cannot_be_unpaused() public view returns (bool) {
+    function echidna_no_transfer() public view returns (bool) {
         return is_paused == true;
     }
 }

--- a/program-analysis/echidna/exercises/exercise2/solution.sol
+++ b/program-analysis/echidna/exercises/exercise2/solution.sol
@@ -8,7 +8,7 @@ contract TestToken is Token {
     }
 
     // add the property
-    function echidna_no_transfer() public view returns (bool) {
+    function echidna_cannot_be_unpaused() public view returns (bool) {
         return is_paused == true;
     }
 }

--- a/program-analysis/echidna/exercises/exercise2/template.sol
+++ b/program-analysis/echidna/exercises/exercise2/template.sol
@@ -1,17 +1,11 @@
 import "token.sol";
 
 contract TestToken is Token {
-
-    constructor() public{
+    constructor() public {
         paused();
         owner = address(0x0); // lose ownership
     }
 
     // add the property
-    function echidna_no_transfer() public view returns(bool){
-
-    }
-
-
+    function echidna_no_transfer() public view returns (bool) {}
 }
-

--- a/program-analysis/echidna/exercises/exercise2/template.sol
+++ b/program-analysis/echidna/exercises/exercise2/template.sol
@@ -2,10 +2,10 @@ import "token.sol";
 
 contract TestToken is Token {
     constructor() public {
-        paused();
+        paused(); // pause the contract
         owner = address(0x0); // lose ownership
     }
 
     // add the property
-    function echidna_no_transfer() public view returns (bool) {}
+    function echidna_cannot_be_unpaused() public view returns (bool) {}
 }

--- a/program-analysis/echidna/exercises/exercise3/solution.sol
+++ b/program-analysis/echidna/exercises/exercise3/solution.sol
@@ -10,7 +10,7 @@ contract TestToken is MintableToken {
     }
 
     // add the property
-    function echidna_cannot_mint_more() public view returns (bool) {
+    function echidna_test_balance() public view returns (bool) {
         return balances[msg.sender] <= 10000;
     }
 }

--- a/program-analysis/echidna/exercises/exercise3/solution.sol
+++ b/program-analysis/echidna/exercises/exercise3/solution.sol
@@ -1,19 +1,15 @@
 import "mintable.sol";
 
-
-contract TestToken is MintableToken{
-
+/// @dev to run: $ echidna-test solution.sol --contract TestToken
+contract TestToken is MintableToken {
     address echidna_caller = msg.sender;
-    constructor() MintableToken(10000) public {
+
+    constructor() public MintableToken(10000) {
         owner = echidna_caller;
     }
 
     // add the property
-    function echidna_test_balance() view public returns(bool){
+    function echidna_test_balance() public view returns (bool) {
         return balances[msg.sender] <= 10000;
-    }   
-
-
-
+    }
 }
-

--- a/program-analysis/echidna/exercises/exercise3/solution.sol
+++ b/program-analysis/echidna/exercises/exercise3/solution.sol
@@ -4,12 +4,13 @@ import "mintable.sol";
 contract TestToken is MintableToken {
     address echidna_caller = msg.sender;
 
+    // update the constructor
     constructor() public MintableToken(10000) {
         owner = echidna_caller;
     }
 
     // add the property
-    function echidna_test_balance() public view returns (bool) {
+    function echidna_cannot_mint_more() public view returns (bool) {
         return balances[msg.sender] <= 10000;
     }
 }

--- a/program-analysis/echidna/exercises/exercise3/template.sol
+++ b/program-analysis/echidna/exercises/exercise3/template.sol
@@ -7,5 +7,5 @@ contract TestToken is MintableToken {
     constructor() public {}
 
     // add the property
-    function echidna_cannot_mint_more() public view returns (bool) {}
+    function echidna_test_balance() public view returns (bool) {}
 }

--- a/program-analysis/echidna/exercises/exercise3/template.sol
+++ b/program-analysis/echidna/exercises/exercise3/template.sol
@@ -1,11 +1,10 @@
-import "token.sol";
+import "mintable.sol";
 
-contract TestToken is Token {
+contract TestToken is MintableToken {
     address echidna_caller = msg.sender;
 
-    constructor() public {
-        balances[echidna_caller] = 10000;
-    }
+    //update the constructor
+    constructor() public {}
 
     // add the property
     function echidna_test_balance() public view returns (bool) {}

--- a/program-analysis/echidna/exercises/exercise3/template.sol
+++ b/program-analysis/echidna/exercises/exercise3/template.sol
@@ -3,9 +3,9 @@ import "mintable.sol";
 contract TestToken is MintableToken {
     address echidna_caller = msg.sender;
 
-    //update the constructor
+    // update the constructor
     constructor() public {}
 
     // add the property
-    function echidna_test_balance() public view returns (bool) {}
+    function echidna_cannot_mint_more() public view returns (bool) {}
 }

--- a/program-analysis/echidna/exercises/exercise4/config.yaml
+++ b/program-analysis/echidna/exercises/exercise4/config.yaml
@@ -1,0 +1,1 @@
+testMode: assertion

--- a/program-analysis/echidna/exercises/exercise4/solution.sol
+++ b/program-analysis/echidna/exercises/exercise4/solution.sol
@@ -1,5 +1,5 @@
 /// @notice there are two ways to run this contract
-/// @dev to run: $ echidna-test solution.sol --test-mode assertion --contract Token
+/// @dev first way to run: $ echidna-test solution.sol --test-mode assertion --contract Token
 /// @dev second way to run: $ echidna-test solution.sol --config config.yaml --contract Token
 contract Ownership {
     address owner = msg.sender;

--- a/program-analysis/echidna/exercises/exercise4/solution.sol
+++ b/program-analysis/echidna/exercises/exercise4/solution.sol
@@ -1,36 +1,46 @@
- contract Ownership{
+/// @notice there are two ways to run this contract
+/// @dev to run: $ echidna-test solution.sol --test-mode assertion --contract Token
+/// @dev second way to run: $ echidna-test solution.sol --config config.yaml --contract Token
+contract Ownership {
     address owner = msg.sender;
+
     function Owner() public {
-         owner = msg.sender;
-     }
-     modifier isOwner(){
-         require(owner == msg.sender);
-         _;
-      }
-   }
-  contract Pausable is Ownership{
-     bool is_paused;
-     modifier ifNotPaused(){
-              require(!is_paused);
-              _;
-      }
-      function paused() isOwner public{
-          is_paused = true;
-      }
-      function resume() isOwner public{
-          is_paused = false;
-      }
-   }
-   contract Token is Pausable{
-      mapping(address => uint) public balances;
-      function transfer(address to, uint value) ifNotPaused public{     
-           uint initial_balance_from = balances[msg.sender];
-           uint initial_balance_to = balances[to];
-           
-           balances[msg.sender] -= value;           
-           balances[to] += value;
-           
-           assert(balances[msg.sender] <= initial_balance_from);
-           assert(balances[to] >= initial_balance_to);           
-       }
+        owner = msg.sender;
     }
+
+    modifier isOwner() {
+        require(owner == msg.sender);
+        _;
+    }
+}
+
+contract Pausable is Ownership {
+    bool is_paused;
+    modifier ifNotPaused() {
+        require(!is_paused);
+        _;
+    }
+
+    function paused() public isOwner {
+        is_paused = true;
+    }
+
+    function resume() public isOwner {
+        is_paused = false;
+    }
+}
+
+contract Token is Pausable {
+    mapping(address => uint256) public balances;
+
+    function transfer(address to, uint256 value) public ifNotPaused {
+        uint256 initial_balance_from = balances[msg.sender];
+        uint256 initial_balance_to = balances[to];
+
+        balances[msg.sender] -= value;
+        balances[to] += value;
+
+        assert(balances[msg.sender] <= initial_balance_from);
+        assert(balances[to] >= initial_balance_to);
+    }
+}

--- a/program-analysis/echidna/exercises/exercise4/token.sol
+++ b/program-analysis/echidna/exercises/exercise4/token.sol
@@ -1,40 +1,37 @@
-contract Ownership{
-
+contract Ownership {
     address owner = msg.sender;
 
-    function Owner() public{
+    function Owner() public {
         owner = msg.sender;
     }
 
-    modifier isOwner(){
+    modifier isOwner() {
         require(owner == msg.sender);
         _;
     }
 }
 
-contract Pausable is Ownership{
-
+contract Pausable is Ownership {
     bool is_paused;
 
-    modifier ifNotPaused(){
+    modifier ifNotPaused() {
         require(!is_paused);
         _;
     }
 
-    function paused() isOwner public{
+    function paused() public isOwner {
         is_paused = true;
     }
 
-    function resume() isOwner public{
+    function resume() public isOwner {
         is_paused = false;
     }
-
 }
 
-contract Token is Pausable{
-    mapping(address => uint) public balances;
+contract Token is Pausable {
+    mapping(address => uint256) public balances;
 
-    function transfer(address to, uint value) ifNotPaused public{
+    function transfer(address to, uint256 value) public ifNotPaused {
         balances[msg.sender] -= value;
         balances[to] += value;
     }

--- a/program-analysis/echidna/filtering-functions.md
+++ b/program-analysis/echidna/filtering-functions.md
@@ -10,7 +10,7 @@
 ## Introduction
 
 We will see how to filter the functions to be fuzzed.
-The target is the following smart contract (*[example/multi.sol](./example/multi.sol)*):: 
+The target is the following smart contract (*[example/multi.sol](./example/multi.sol)*): 
 
 ```solidity
 contract C {

--- a/program-analysis/echidna/filtering-functions.md
+++ b/program-analysis/echidna/filtering-functions.md
@@ -10,7 +10,7 @@
 ## Introduction
 
 We will see how to filter the functions to be fuzzed.
-The target is the following smart contract: 
+The target is the following smart contract (*[example/multi.sol](./example/multi.sol)*):: 
 
 ```solidity
 contract C {
@@ -76,7 +76,7 @@ Seed: -3684648582249875403
 ## Filtering functions
 
 Echidna has trouble finding the correct sequence to test this contract because the two reset functions (`reset1` and `reset2`) will set all the state variables to `false`. 
-However, we can use a special Echidna feature to either blacklist the reset function or to whitelist only the `f`, `g`, 
+However, we can use a special Echidna feature to either blacklist the `reset` functions or to whitelist only the `f`, `g`, 
 `h` and `i` functions. 
 
 To blacklist functions, we can use this configuration file:
@@ -94,7 +94,7 @@ filterFunctions: ["C.f(uint256)", "C.g(uint256)", "C.h(uint256)", "C.i()"]
 ```
 
 - `filterBlacklist` is `true` by default.
-- Filtering will be performed by full function name (contract name + "." + ABI). If you have `f()` and `f(uint256)`, you can specify exactly which function to filter.
+- Filtering will be performed by full function name (contract name + "." + ABI function signature). If you have `f()` and `f(uint256)`, you can specify exactly which function to filter.
 
 # Run Echidna
 
@@ -111,7 +111,7 @@ echidna_state4: failed!💥
     i()
 ```
 
-Echidna will find the sequence of transactions to falsify the property almost inmmediately. 
+Echidna will find the sequence of transactions to falsify the property almost immediately. 
 
 
 ## Summary: Filtering functions
@@ -128,5 +128,4 @@ $ echidna-test contract.sol --config config.yaml
 ...
 ```
 
-Echidna starts a fuzzing campaign either blacklisting `C.f1()`, `C.f2()` and `C.f3()` or only calling these, according
-to the value of the `filterBlacklist` boolean.
+According to the value of the `filterBlacklist` boolean, Echidna will start a fuzzing campaign by either blacklisting `C.f1()`, `C.f2()` and `C.f3()` or by _only_ calling those functions.

--- a/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
+++ b/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
@@ -157,4 +157,4 @@ $ echidna-test contract.sol --config config.yaml
 ...
 ```
 
-Echidna will report a sequence with the maximum gas consumption for every function, once the fuzzing campaign is over.
+Once the fuzzing campaign is over, Echidna will report a sequence with the maximum gas consumption for every function.

--- a/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
+++ b/program-analysis/echidna/finding-transactions-with-high-gas-consumption.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-We will see how to find the transactions with has gas consumption with Echidna. The target is the following smart contract:
+We will see how to find transactions with has gas consumption using Echidna. The target is the following smart contract (*[example/gas.sol](./example/gas.sol)*):
 
 ```solidity
 contract C {
@@ -36,7 +36,7 @@ contract C {
 ```
 Here `expensive` can have a large gas consumption. 
 
-Currently, Echidna always need a property to test: here `echidna_test` always returns `true`.
+Currently, Echidna always needs a property to test: here `echidna_test` always returns `true`.
 We can run Echidna to verify this:
 
 ```
@@ -49,7 +49,7 @@ Seed: 2320549945714142710
 
 ## Measuring Gas Consumption
 
-To enable the gas consumption with Echidna, create an configuration file `config.yaml`:
+To enable Echidna's gas consumption feature, create a configuration file [`config.yaml`](./example/gas.yaml):
 
 ```yaml
 estimateGas: true
@@ -86,9 +86,9 @@ Seed: -325611019680165325
 # Filtering Out Gas-Reducing Calls
 
 The tutorial on [filtering functions to call during a fuzzing campaign](./filtering-functions.md) shows how to
-remove some functions from your testing.  
+remove some functions during testing.  
 This can be critical for getting an accurate gas estimate.
-Consider the following example:
+Consider the following example (*[example/pushpop.sol](./example/pushpop.sol)*):
 
 ```solidity
 contract C {
@@ -113,7 +113,7 @@ contract C {
   }
 }
 ```
-If Echidna can call all the functions, it won't easily find transactions with high gas cost:
+If Echidna uses this [`config.yaml`](./example/pushpop.yaml), it can call all functions and won't easily find transactions with high gas cost:
 
 ```
 $ echidna-test pushpop.sol --config config.yaml
@@ -128,9 +128,10 @@ push used a maximum of 40839 gas
 ```
 
 That's because the cost depends on the size of `addrs` and random calls tend to leave the array almost empty.
-Blacklisting `pop` and `clear`, however, gives us much better results:
+Blacklisting `pop` and `clear`, however, gives us much better results (*[example/blacklistpushpop.yaml](./example/blacklistpushpop.yaml)*):
 
 ```yaml
+estimateGas: true
 filterBlacklist: true
 filterFunctions: ["C.pop()", "C.clear()"]
 ```

--- a/program-analysis/echidna/fuzzing-introduction.md
+++ b/program-analysis/echidna/fuzzing-introduction.md
@@ -8,15 +8,15 @@ Fuzzing is a well-known technique in the security community. It consists of gene
 
 Beyond the purely random generation of inputs, there are many techniques and strategies to generate good inputs, including:
 
-- Obtain feedback from each execution and guide generation using it. For example, if a newly generated input leads to the discovery of a new path, it can make sense to generate new inputs closes to it.
-- Generating the input respecting a structural constraint. For example, if you input contains a header with a checksum, it will make sense to let the fuzzer generates input validating the checksum.
-- Using known inputs to generate new inputs: if you have access to a large dataset of valid input, your fuzzer can generate new inputs from them, rather than starting from scratch its generation. These are usually called *seeds*.
+- Obtain feedback from each execution and guide generation using it. For example, if a newly generated input leads to the discovery of a new path, it makes sense to generate new inputs closest to it.
+- Generate input with respect to a structural constraint. For example, if your input contains a header with a checksum, it makes sense to let the fuzzer generate input validating the checksum.
+- Use known inputs to generate new inputs. If you have access to a large dataset of valid input, your fuzzer can generate new inputs from them, rather than starting from scratch. These are usually called *seeds*.
 
 ## Property-based fuzzing
 
 Echidna belongs to a specific family of fuzzer: property-based fuzzing heavily inspired by [QuickCheck](https://en.wikipedia.org/wiki/QuickCheck). In contrast to a classic fuzzer that will try to find crashes, Echidna will try to break user-defined invariants.
 
-In smart contracts, invariants are Solidity functions that can represent any incorrect or invalid state that the contract can reach, including:
+In smart contracts, invariants are Solidity functions or properties that can represent any incorrect or invalid state that the contract can reach, including:
 
 - Incorrect access control: the attacker became the owner of the contract.
 - Incorrect state machine: the tokens can be transferred while the contract is paused.

--- a/program-analysis/echidna/fuzzing-introduction.md
+++ b/program-analysis/echidna/fuzzing-introduction.md
@@ -8,9 +8,9 @@ Fuzzing is a well-known technique in the security community. It consists of gene
 
 Beyond the purely random generation of inputs, there are many techniques and strategies to generate good inputs, including:
 
-- Obtain feedback from each execution and guide generation using it. For example, if a newly generated input leads to the discovery of a new path, it makes sense to generate new inputs closest to it.
-- Generate input with respect to a structural constraint. For example, if your input contains a header with a checksum, it makes sense to let the fuzzer generate input validating the checksum.
-- Use known inputs to generate new inputs. If you have access to a large dataset of valid input, your fuzzer can generate new inputs from them, rather than starting from scratch. These are usually called *seeds*.
+- **Obtain feedback from each execution and guide generation using it**. For example, if a newly generated input leads to the discovery of a new path, it makes sense to generate new inputs closest to it.
+- **Generate input with respect to a structural constraint**. For example, if your input contains a header with a checksum, it makes sense to let the fuzzer generate input validating the checksum.
+- **Use known inputs to generate new inputs**. If you have access to a large dataset of valid input, your fuzzer can generate new inputs from them, rather than starting from scratch for each generation. These are usually called *seeds*.
 
 ## Property-based fuzzing
 

--- a/program-analysis/echidna/fuzzing-introduction.md
+++ b/program-analysis/echidna/fuzzing-introduction.md
@@ -16,7 +16,7 @@ Beyond the purely random generation of inputs, there are many techniques and str
 
 Echidna belongs to a specific family of fuzzer: property-based fuzzing heavily inspired by [QuickCheck](https://en.wikipedia.org/wiki/QuickCheck). In contrast to a classic fuzzer that will try to find crashes, Echidna will try to break user-defined invariants.
 
-In smart contracts, invariants are Solidity functions or properties that can represent any incorrect or invalid state that the contract can reach, including:
+In smart contracts, invariants are Solidity functions that can represent any incorrect or invalid state that the contract can reach, including:
 
 - Incorrect access control: the attacker became the owner of the contract.
 - Incorrect state machine: the tokens can be transferred while the contract is paused.

--- a/program-analysis/echidna/fuzzing_tips.md
+++ b/program-analysis/echidna/fuzzing_tips.md
@@ -70,7 +70,7 @@ function operation(...) public{
 }
 ```
 
-This will work well to test arrays with a small amount of elements, however, it introduces an unexpected bias in the exploration: since `push` an `pop` are functions that will be selected with equal probability, the chance of building large arrays (e.g. more than 64 elements) is very very small. One quick solution could be to run Echidna blacklisting the `pop()` during a short campaign:
+This will work well to test arrays with a small amount of elements; however, it introduces an unexpected bias in the exploration: since `push` an `pop` are functions that will be selected with equal probability, the chance of building large arrays (e.g. more than 64 elements) is very very small. One quick solution could be to blacklist the `pop()` function during a short campaign:
 
 ```
 filterFunctions: ["C.pop()"]

--- a/program-analysis/echidna/fuzzing_tips.md
+++ b/program-analysis/echidna/fuzzing_tips.md
@@ -16,7 +16,7 @@ function operation(uint index, ...) public{
 }
 ```
 
-If `require(index <= 10**18)` is used instead, many transactions generated will revert, slowling the fuzzer. 
+If `require(index <= 10**18)` is used instead, many transactions generated will revert, slowing the fuzzer. 
 
 This can also be generalized define a min and max range, for example:
 
@@ -28,7 +28,7 @@ function operation(uint balance, ...) public{
 }
 ```
 
-Will ensure that `balance` is always between `MIN_BALANCE` and `MAX_BALANCE`, without discarding any generated transactions. As expected, this will speed up the exploration, but at the cost of avoiding certain path in your code. To overcome this issue, the usual solution is to have two functions:
+Will ensure that `balance` is always between `MIN_BALANCE` and `MAX_BALANCE`, without discarding any generated transactions. As expected, this will speed up the exploration, but at the cost of avoiding certain paths in your code. To overcome this issue, the usual solution is to have two functions:
 
 ```solidity
 function operation(uint balance, ...) public{
@@ -41,7 +41,7 @@ function safeOperation(uint balance, ...) public{
 }
 ```
 
-So Echidna is free to use any of these, exploring safe and usafe usage of the input data.
+So Echidna is free to use any of these, exploring safe and unsafe usage of the input data.
 
 # Dealing with dynamic arrays
 
@@ -53,7 +53,7 @@ function operation(uint256[] data, ...) public{
 }
 ```
 
-This is because deserializing dynamic array is slow and can take a some amount of memory during the execution. Dynamic arrays are also problematic since they are hard to mutate. Despite Echidna includes some specific mutators (to remove/repeat elements or cut them), the mutators are performed using the collected corpus. That is why we suggest to use an functions `push(..)` and `pop()` to handle the exporation of dynamic array used as inputs:
+This is because deserializing dynamic arrays is slow and can take some amount of memory during the execution. Dynamic arrays are also problematic since they are hard to mutate. Despite this, Echidna includes some specific mutators to remove/repeat elements or cut elements. These mutators are performed using the collected corpus. In general, we suggest the use of `push(..)` and `pop()` functions to handle the exploration of dynamic arrays used as inputs:
 
 ```solidity
 private uint256[] data;
@@ -70,10 +70,10 @@ function operation(...) public{
 }
 ```
 
-This will work well to test arrays with a small amount of elements, however, it introduces an unexpected bias in the exploration: since `push` an `pop` are functions that will be selected with equal probability, the chance of builiding large arrays (e.g. more than 64 elements) is very very small. One quick solution could be to run Echidna blacklisting the `pop()` during a short campaign:
+This will work well to test arrays with a small amount of elements, however, it introduces an unexpected bias in the exploration: since `push` an `pop` are functions that will be selected with equal probability, the chance of building large arrays (e.g. more than 64 elements) is very very small. One quick solution could be to run Echidna blacklisting the `pop()` during a short campaign:
 
 ```
 filterFunctions: ["C.pop()"]
 ```
 
-This is enough for small scale testing. A more general solution is available using a specific testing technique called [*swarm testing*](https://www.cs.utah.edu/~regehr/papers/swarm12.pdf). This allows to run a long testing campaign with some tool but randomly shuffling the configuration of it. In case of Echidna, swarm testing runs with different config files, where it blacklists an amount of random functions from the contract to test. We offer swarm testing and scalability with [echidna-parade](https://github.com/crytic/echidna-parade), our dedicated tool for fuzzing smart contracts. A specific tutorial in the use of echidna-parade is available [here](smart-contract-fuzzing-at-scale.md).
+This is enough for small scale testing. A more general solution is available using a specific testing technique called [*swarm testing*](https://www.cs.utah.edu/~regehr/papers/swarm12.pdf). This allows to run a long testing campaign with some tool but randomly shuffling the configuration of it. In case of Echidna, swarm testing runs with different config files, where it blacklists some number of random functions from the contract before testing. We offer swarm testing and scalability with [echidna-parade](https://github.com/crytic/echidna-parade), our dedicated tool for fuzzing smart contracts. A specific tutorial in the use of echidna-parade is available [here](smart-contract-fuzzing-at-scale.md).

--- a/program-analysis/echidna/how-to-test-a-property.md
+++ b/program-analysis/echidna/how-to-test-a-property.md
@@ -30,7 +30,7 @@ We will see how to test a smart contract with Echidna. The target is the followi
   
 ```
 
-We will make the assumption that this token must have the following properties:
+We will make the assumption that this token has the following properties:
 
 - Anyone can have at maximum 1000 tokens
 
@@ -46,7 +46,7 @@ Echidna properties are Solidity functions. A property must:
 Echidna will:
 - Automatically generate arbitrary transactions to test the property.
 - Report any transactions leading a property to return false or throw an error. 
-- Discard side-effect when calling a property (i.e. if the property changes a state variable, it is discarded after the test)
+- Discard side-effects when calling a property (i.e. if the property changes a state variable, it is discarded after the test)
 
 The following property checks that the caller has no more than 1000 tokens:
 
@@ -79,7 +79,7 @@ There are some specific addresses in Echidna:
 
 - `0x10000`, `0x20000`, and `0x30000` randomly call the other functions.
 
-We do not need any particular initialization in our current example, as a result our constructor is empty.
+We do not need any particular initialization in our current example. As a result, our constructor is empty.
 
 ## Run Echidna
 
@@ -89,7 +89,7 @@ Echidna is launched with:
 $ echidna-test contract.sol
 ```
 
-If contract.sol contains multiple contracts, you can specify the target:
+If `contract.sol` contains multiple contracts, you can specify the target:
 
 ```bash
 $ echidna-test contract.sol --contract MyContract

--- a/program-analysis/echidna/how-to-test-a-property.md
+++ b/program-analysis/echidna/how-to-test-a-property.md
@@ -48,7 +48,7 @@ Echidna will:
 - Report any transactions leading a property to return false or throw an error. 
 - Discard side-effects when calling a property (i.e. if the property changes a state variable, it is discarded after the test)
 
-The following property checks that the caller has no more than 1000 tokens:
+The following property checks that the caller can have no more than 1000 tokens:
 
 ```Solidity
     function echidna_balance_under_1000() public view returns(bool){
@@ -70,7 +70,7 @@ Use inheritance to separate your contract from your properties:
 
 ## Initiate a contract
 
-Echidna needs a constructor without argument.
+Echidna needs a constructor without input arguments.
 If your contract needs a specific initialization, you need to do it in the constructor.
 
 There are some specific addresses in Echidna:
@@ -97,7 +97,7 @@ $ echidna-test contract.sol --contract MyContract
 
 ## Summary: Testing a property
 
-The following summarizes the run of echidna on our example:
+The following summarizes the run of Echidna on our example:
 
 ```Solidity
      contract TestToken is Token{

--- a/program-analysis/echidna/how-to-test-a-property.md
+++ b/program-analysis/echidna/how-to-test-a-property.md
@@ -75,9 +75,9 @@ If your contract needs a specific initialization, you need to do it in the const
 
 There are some specific addresses in Echidna:
 
-- `0x00a329c0648769A73afAc7F9381E08FB43dBEA72` which calls the constructor.
+- `0x30000` calls the constructor.
 
-- `0x10000`, `0x20000`, and `0x00a329C0648769a73afAC7F9381e08fb43DBEA70` which randomly calls the other functions.
+- `0x10000`, `0x20000`, and `0x30000` randomly call the other functions.
 
 We do not need any particular initialization in our current example, as a result our constructor is empty.
 

--- a/program-analysis/echidna/property-creation.md
+++ b/program-analysis/echidna/property-creation.md
@@ -157,7 +157,7 @@ The resulting property checks that calls to deposit/withdraw shares will never r
 
 Two important considerations for this example:
 
-We want echidna to spend most of the execution exploring the contract to test. So, in order to make the properties more efficient, we should avoid dead branches where there is nothing to do. That's why we can improve `depositShares_never_reverts` to use:
+We want Echidna to spend most of the execution exploring the contract to test. So, in order to make the properties more efficient, we should avoid dead branches where there is nothing to do. That's why we can improve `depositShares_never_reverts` to use:
 
 ```solidity
   function depositShares_never_reverts(uint256 val) public {
@@ -171,7 +171,7 @@ We want echidna to spend most of the execution exploring the contract to test. S
   }
 ```
 
-Additionally, combining properties does not mean that we will have to remove simpler ones. For instance, if we want to write `withdraw_deposit_shares_never_reverts`, in which we reverse the order of operations (withdraw and then deposit, instead of deposit and then withdraw), we will have to make sure `c.getShares(address(this))` can be positive. An easy way to do it is to keep `depositShares_never_reverts`, since this code allows Echidna to deposit shares from `address(this)` (otherwise, this is impossible).
+Additionally, combining properties does not mean that we will have to remove simpler ones. For instance, if we want to write `withdraw_deposit_shares_never_reverts`, in which we reverse the order of operations (withdraw and then deposit, instead of deposit and then withdraw), we will have to make sure `c.getShares(address(this))` can be positive. An easy way to do it is to keep `depositShares_never_reverts`, since this code allows Echidna to deposit tokens from `address(this)` (otherwise, this is impossible).
 
 ## Summary: How to write good properties
 

--- a/program-analysis/echidna/property-creation.md
+++ b/program-analysis/echidna/property-creation.md
@@ -10,25 +10,26 @@
 
 ## Introduction
 
-In this short tutorial, we will detail some ideas to write interesting or useful properties using Echidna, in an iteratively process where we improved them at each steap.
+In this short tutorial, we will detail some ideas to write interesting or useful properties using Echidna. At each step, we will iteratively improve our properties.
 
 ## A first approach
 
-One of the simplest properties to write using Echidna are going to assert when some function should revert/return exactly.
+One of the simplest properties to write using Echidna is to throw an assertion when some function is expected to revert/return.
 
-Let's suppose we have a contract like this one: 
+Let's suppose we have a contract interface like the one below: 
 
 ```solidity
 interface DeFi {
   ERC20 t;
   function getShares(address user) external returns (uint256)
   function createShares(uint256 val) external returns (uint256)
+  function depositShares(uint256 val) external
   function withdrawShares(uint256 val) external
   function transferShares(address to) external
   ...
 ```
 
-In this example, users can deposit tokens from `token` to mint shares using `createShares`. They can withdraw shares using `withdrawShares` or transfer all of them to another user another using `transferShares`. Finally `getShares` will return the number of shares for every account. We will start with very basic properties:
+In this example, users can deposit tokens using `depositShares`, mint shares using `createShares`, withdraw shares using `withdrawShares`, transfer all shares to another user using `transferShares`, and get the number of shares for any account using `getShares`. We will start with very basic properties:
 
 ```solidity
 contract Test {
@@ -76,12 +77,12 @@ contract Test {
 }
 ```
 
-After you have write your first version of properties, run Echidna to make sure they work as expected. During this tutorial, we will improve them step by step, it is strongly recommended to run the fuzzer at each step, to increase the probability of detecting any potential issue. 
+After you have writen your first version of properties, run Echidna to make sure they work as expected. During this tutorial, we will improve them step by step. It is strongly recommended to run the fuzzer at each step to increase the probability of detecting any potential issues. 
 
-Perhaps you think this properties are too low level to be useful, in particular if the code has a good coverage in terms of unit tests, 
-but you will be surpriced how often an unexpected reverts/returns uncovers a complex and severe issue. Moreover, we will see how these properties can be improved to cover more complex post-conditions.
+Perhaps you think these properties are too low level to be useful, particularly if the code has a good coverage in terms of unit tests.
+But you will be surprised how often an unexpected revert/return uncovers a complex and severe issue. Moreover, we will see how these properties can be improved to cover more complex post-conditions.
 
-Before continue, we will improve these properties using [try/catch](https://docs.soliditylang.org/en/v0.6.0/control-structures.html#try-catch). The use of a low level call force us to manually encode the data, which can be error prone (an error will cause calls to always revert). However, this will only works if the codebase is using solc 0.6.0 or later:
+Before we continue, we will improve these properties using [try/catch](https://docs.soliditylang.org/en/v0.6.0/control-structures.html#try-catch). The use of a low-level call forces us to manually encode the data, which can be error prone (an error will always cause calls to revert). Note, this will only work if the codebase is using solc 0.6.0 or later:
 
 
 ```solidity
@@ -105,7 +106,7 @@ Before continue, we will improve these properties using [try/catch](https://docs
 ## Enhacing postcondition checks
 
 If the previous properties are passing, this means that the pre-conditions are good enough, however the post-conditions are not very precise. 
-Avoid reverting doesn't mean that the contract is in a valid state. Let's add some basic preconditions:
+Avoiding reverts doesn't mean that the contract is in a valid state. Let's add some basic preconditions:
 
 ```solidity
   ...
@@ -127,11 +128,11 @@ Avoid reverting doesn't mean that the contract is in a valid state. Let's add so
 }
 ```
 
-Uhm, it looks like it is not that easy to specifying the value of shares/tokens obtained after each deposit/withdrawal. At least we can say that we must receveive something, right?
+Uhm, it looks like it is not that easy to specify the value of shares/tokens obtained after each deposit/withdrawal. At least we can say that we must receive something, right?
 
 ## Combining properties
 
-In this generic example, it is unclear if there is a way to calculate how many shares or tokens we should receive after executing the deposit/withdraw operations. Of course, if we have that information, we should use it. In any case, what we can do here is to combine these two properties in a single one to be able check more precisely it's preconditions. 
+In this generic example, it is unclear if there is a way to calculate how many shares or tokens we should receive after executing the deposit/withdraw operations. Of course, if we have that information, we should use it. In any case, what we can do here is to combine these two properties into a single one to be able check more precisely it's preconditions. 
 
 ```solidity
   ...
@@ -150,13 +151,13 @@ In this generic example, it is unclear if there is a way to calculate how many s
 }
 ```
 
-The resulting property checks that calls to deposit/withdraw shares will never revert and once they executed, the number of obtained tokens will not change. Keep in mind that this property should consider fees and any tolerated loss of precision (e.g. when the computation requires a division).
+The resulting property checks that calls to deposit/withdraw shares will never revert and once they execute, the original number of tokens remains the same. Keep in mind that this property should consider fees and any tolerated loss of precision (e.g. when the computation requires a division).
 
 ## Final considerations
 
 Two important considerations for this example:
 
-We want echidna to spend most of the execution exploring the contract to test, so in order to make the properties more efficient, we should avoid dead branches where there is nothing to do. That's why we can improve `depositShares_never_reverts` to use:
+We want echidna to spend most of the execution exploring the contract to test. So, in order to make the properties more efficient, we should avoid dead branches where there is nothing to do. That's why we can improve `depositShares_never_reverts` to use:
 
 ```solidity
   function depositShares_never_reverts(uint256 val) public {
@@ -170,8 +171,8 @@ We want echidna to spend most of the execution exploring the contract to test, s
   }
 ```
 
-Additionally, combining properties does not mean that we will have to remove simpler ones. For instance, if we want to write `withdraw_deposit_shares_never_reverts`, in which we reverse the order of operations (withdraw and then deposit, instead of deposit and then withdraw), we will have to make sure `c.getShares(address(this))` can be positive. An easy way to do it is to keep `depositShares_never_reverts`, since this code allows Echidna to deposit shares into the `address(this)` (otherwise, this is impossible).
+Additionally, combining properties does not mean that we will have to remove simpler ones. For instance, if we want to write `withdraw_deposit_shares_never_reverts`, in which we reverse the order of operations (withdraw and then deposit, instead of deposit and then withdraw), we will have to make sure `c.getShares(address(this))` can be positive. An easy way to do it is to keep `depositShares_never_reverts`, since this code allows Echidna to deposit shares from `address(this)` (otherwise, this is impossible).
 
 ## Summary: How to write good properties
 
-It is usually a good idea to start writting simple properties first and then improving them to make then more precise and easier to read. At each step you should run a short fuzzing campaign to make sure they work as expected and try to catch issues early during the development of your smart contracts. 
+It is usually a good idea to start writing simple properties first and then improving them to make them more precise and easier to read. At each step you should run a short fuzzing campaign to make sure they work as expected and try to catch issues early during the development of your smart contracts. 

--- a/program-analysis/echidna/smart-contract-fuzzing-at-scale.md
+++ b/program-analysis/echidna/smart-contract-fuzzing-at-scale.md
@@ -12,7 +12,7 @@ In this tutorial we will review how we can create a dedicated server for fuzzing
 
 ## 1. Install and setup a dedicated server
 
-First, obtain a dedicated server with at least 32 GB of RAM and as many cores as possible. Start creating a user for the fuzzing. 
+First, obtain a dedicated server with at least 32 GB of RAM and as many cores as possible. Start by creating a user for the fuzzing campaign. 
 **Only use the root acount to create an unprivileged user**: 
 
 ```
@@ -26,7 +26,7 @@ Then, using that user (`echidna`), install some basic dependencies:
 $ sudo apt install unzip python3-pip
 ```
 
-Then install everything necessary to build your smart contract as well to run `slither` and `echidna-parade`. For instance:
+Then install everything necessary to build your smart contract(s) as well `slither` and `echidna-parade`. For instance:
 
 ```
 $ pip3 install solc-select
@@ -37,7 +37,7 @@ $ pip3 install echidna_parade
 
 Add `$PATH=$PATH:/home/echidna/.local/bin` at the end of `/home/echidna/.bashrc`
 
-We should install echidna. The easiest way is to download a precompiled version of echidna, uncompress it and move it to `/home/echidna/.local/bin`:
+Next, install echidna. The easiest way is to download a precompiled version of echidna, uncompress it and move it to `/home/echidna/.local/bin`:
 
 ```
 $ wget "https://github.com/crytic/echidna/releases/download/v1.7.2/echidna-test-1.7.2-Ubuntu-18.04.tar.gz"
@@ -54,14 +54,14 @@ Before starting this campaign, modify your echidna config to define a corpus dir
 corpusDir: "corpus-exploration"
 ```
 
-This directory will be automatically created but since we are starting a new campaign, **please remove the corpus directory if it was created by previous echidna campaign**. 
+This directory will be automatically created but since we are starting a new campaign, **please remove the corpus directory if it was created by a previous echidna campaign**. 
 If you don't have any properties to test, you can use:
 
 ```
 benchmarkMode: true
 ```
 
-to allow echidna to run without any property. 
+to allow echidna to run without any properties. 
  
 We will start a very short echidna run (5 minutes), to check that everything looks fine. To do that, use the following config:
 
@@ -77,13 +77,13 @@ After it runs, check the coverage file, located in `corpus-exploration/covered.*
 
 When you are satisfied with the first iteration of the initialization, we can start a "continuous campaign" for exploration and testing using [echidna-parade](https://github.com/agroce/echidna-parade). Before starting, double check your config file. For instance, if you added properties, do not forget to remove `benchmarkMode`.
 
-echidna-parade is tool is used to launch echidna instances at the same time, keeping track of the corpora of each one. Each instance will be configured to run for a certain amount of time with different parameters in order to maximize the chance to reach new code.
+`echidna-parade` is a tool is used to launch echidna instances at the same time, keeping track of the corpora of each one. Each instance will be configured to run for a certain amount of time, with different parameters, in order to maximize the chance to reach new code.
 
 We will show it with an example, where:
 * the initial corpus is empty
 * the base config file will be exploration.yaml
 * the time to run the initial instance will be 3600 seconds (1 hour)
-* the time to run each "generations" will be 1800 seconds (30 minutes)
+* the time to run each "generation" will be 1800 seconds (30 minutes)
 * the campaign will run in continuous mode (if timeout is -1, it means run forever)
 * the number of echidna instances per generation will be 8. This should be adjusted according to the number of available cores but avoid using all your cores if you don't want to kill your server
 * the target contract is named `C`
@@ -95,7 +95,7 @@ Finally, we will log the stdout and stderr in `parade.log` and `parade.err` and 
 $ echidna-parade test.sol --config exploration.yaml --initial_time 3600 --gen_time 1800 --timeout -1 --ncores 8 --contract C > parade.log 2> parade.err &
 ```
 
-**After you run this command, exit the shell so you won't kill it accidentally if your connect fails.**
+**After you run this command, exit the shell so you won't kill it accidentally if your connection fails.**
 
 ## 4. Add more properties, check coverage and modify the code if necessary
 
@@ -121,7 +121,7 @@ COLLECTING NEW COVERAGE: parade.181140/gen.37.6/corpus/coverage/6733481703877290
 
 you can verify the corresponding covered file, such as `parade.181140/gen.37.6/corpus/covered.1615497368.txt`. 
 
-For examples on how to help echidna to improve its coverage, please review the improving coverage tutorial.
+For examples on how to help echidna to improve its coverage, please review the [improving coverage tutorial](./collecting-a-corpus.md).
 
 To monitor failed properties, use this command:
 

--- a/program-analysis/echidna/smart-contract-fuzzing-at-scale.md
+++ b/program-analysis/echidna/smart-contract-fuzzing-at-scale.md
@@ -37,7 +37,7 @@ $ pip3 install echidna_parade
 
 Add `$PATH=$PATH:/home/echidna/.local/bin` at the end of `/home/echidna/.bashrc`
 
-Next, install echidna. The easiest way is to download a precompiled version of echidna, uncompress it and move it to `/home/echidna/.local/bin`:
+Next, install Echidna. The easiest way is to download a precompiled version of Echidna, uncompress it, and move it to `/home/echidna/.local/bin`:
 
 ```
 $ wget "https://github.com/crytic/echidna/releases/download/v1.7.2/echidna-test-1.7.2-Ubuntu-18.04.tar.gz"
@@ -61,9 +61,9 @@ If you don't have any properties to test, you can use:
 benchmarkMode: true
 ```
 
-to allow echidna to run without any properties. 
+to allow Echidna to run without any properties. 
  
-We will start a very short echidna run (5 minutes), to check that everything looks fine. To do that, use the following config:
+We will start a very short Echidna run (5 minutes), to check that everything looks fine. To do that, use the following config:
 
 ```
 testLimit: 100000000000
@@ -77,15 +77,15 @@ After it runs, check the coverage file, located in `corpus-exploration/covered.*
 
 When you are satisfied with the first iteration of the initialization, we can start a "continuous campaign" for exploration and testing using [echidna-parade](https://github.com/agroce/echidna-parade). Before starting, double check your config file. For instance, if you added properties, do not forget to remove `benchmarkMode`.
 
-`echidna-parade` is a tool is used to launch echidna instances at the same time, keeping track of the corpora of each one. Each instance will be configured to run for a certain amount of time, with different parameters, in order to maximize the chance to reach new code.
+`echidna-parade` is a tool is used to launch multiple Echidna instances at the same time, keeping track of the corpora of each one. Each instance will be configured to run for a certain amount of time, with different parameters, in order to maximize the chance to reach new code.
 
 We will show it with an example, where:
 * the initial corpus is empty
-* the base config file will be exploration.yaml
+* the base config file will be `exploration.yaml`
 * the time to run the initial instance will be 3600 seconds (1 hour)
 * the time to run each "generation" will be 1800 seconds (30 minutes)
 * the campaign will run in continuous mode (if timeout is -1, it means run forever)
-* the number of echidna instances per generation will be 8. This should be adjusted according to the number of available cores but avoid using all your cores if you don't want to kill your server
+* the number of Echidna instances per generation will be 8. This should be adjusted according to the number of available cores, but avoid using all your cores if you don't want to kill your server
 * the target contract is named `C`
 * the file that contains the contract is `test.sol`
 
@@ -121,7 +121,7 @@ COLLECTING NEW COVERAGE: parade.181140/gen.37.6/corpus/coverage/6733481703877290
 
 you can verify the corresponding covered file, such as `parade.181140/gen.37.6/corpus/covered.1615497368.txt`. 
 
-For examples on how to help echidna to improve its coverage, please review the [improving coverage tutorial](./collecting-a-corpus.md).
+For examples on how to help Echidna to improve its coverage, please review the [improving coverage tutorial](./collecting-a-corpus.md).
 
 To monitor failed properties, use this command:
 

--- a/program-analysis/echidna/testing-bytecode.md
+++ b/program-analysis/echidna/testing-bytecode.md
@@ -10,8 +10,8 @@
 
 ## Introduction
 
-We will see how to fuzz a contract without providing the source code. 
-The technique can used to do differential fuzzing (i.e. compare multiple implementations) between a Solidity contract, a Vyper contract, or without source code.
+We will see how to fuzz a contract without any provided source code. 
+The technique can also be used to perform differential fuzzing (i.e. compare multiple implementations) between a Solidity contract and a Vyper contract.
 
 Consider the following bytecode:
 ```
@@ -68,9 +68,9 @@ contract TestBytecodeOnly{
 ```
 
 The proxy:
-- Deploy the bytecode in its constructor
+- Deploys the bytecode in its constructor
 - Has one function that will call the target's `transfer` function
-- Has one echidna property `t.balanceOf(address(this)) <= t.totalSupply()`
+- Has one Echidna property `t.balanceOf(address(this)) <= t.totalSupply()`
 
 ## Run Echidna
 

--- a/program-analysis/echidna/testing-bytecode.md
+++ b/program-analysis/echidna/testing-bytecode.md
@@ -11,7 +11,7 @@
 ## Introduction
 
 We will see how to fuzz a contract without providing the source code. 
-The technique can used to do differential fuzzing (i.e. compare multiple implementations) between a Solidity contract, and a Vyper contract, or without source code.
+The technique can used to do differential fuzzing (i.e. compare multiple implementations) between a Solidity contract, a Vyper contract, or without source code.
 
 Consider the following bytecode:
 ```
@@ -81,7 +81,7 @@ echidna_test_balance: failed!💥
     transfer(0x0,1002)
 ```
 
-Here Echidna found that by calling `transfer(0 ,1002)` anyone can mint tokens. 
+Here Echidna found that by calling `transfer(0, 1002)` anyone can mint tokens. 
 
 ### Target source code
 
@@ -157,11 +157,9 @@ contract SolidityVersion{
 }
 ```
 
-Here we run Echidna with the [assertion mode](https://github.com/crytic/building-secure-contracts/blob/master/program-analysis/echidna/assertion-checking.md):
+Here we run Echidna with the [assertion mode](./assertion-checking.md):
 ```
-$ cat config.yaml 
-checkAsserts: true
-$ echidna-test  vyper.sol --config config.yaml --contract SolidityVersion
+$ echidna-test  vyper.sol --config config.yaml --contract SolidityVersion --test-mode assertion
 assertion in test: passed! 🎉
 ```
 


### PR DESCRIPTION
Here are the following changes:
- Updated all exercises to use `msg.sender` instead of a hardcoded address for `echidna_caller`
- Added a line in each solution to show users how to run the `solution.sol` file with Echidna
- Added a `template.sol` for exercise3
- Tested that all exercises work with Echidna 2.0
- Ensured that all references to deprecated configuration options were removed / replaced
- Fixed some grammatical issues in all markdown files
- Fixed the different sender addresses in `how-to-test-a-property.md`
- Added hyperlinks to files in the `example/` wherever applicable