### PR TITLE
[WIP] Adding exercises 5 and 6 from dvdefi

### DIFF
--- a/program-analysis/echidna/Exercise-5.md
+++ b/program-analysis/echidna/Exercise-5.md
@@ -1,0 +1,56 @@
+# Exercise 5
+
+**Table of contents:**
+
+- [Exercise 5](#exercise-5)
+  - [Setup](#setup)
+  - [Exercise](#exercise)
+  - [Solution](#solution)
+
+Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum
+
+## Setup
+
+1. Follow the instructions on the [Damn Vulnerable DeFi CTF][ctf] page, namely:
+    - clone the repo, and
+    - install the dependencies.
+2. Create a contract called `UnstoppableEchidna` in the `contract/unstoppable` directory.
+3. Analyze the `before` function in `test/unstoppable/unstoppable.challenge.js` to identify what initial setup needs to be done.
+
+Hint: You don't need to make the setup very complex. It is possible to find the bug with just three contracts:
+  - `DamnValuableToken`
+  - `UnstoppableLender`
+  - `ReceiverUnstoppable`
+
+## Goals
+
+- Setup the testing environment with the right contracts and necessary balances.
+- Add a property to check whether `UnstoppableLender` can always provide flash loans.
+- Create `config.yaml` with the necessary configuration option(s).
+- Once Echidna finds the bug, fix the issue, and re-try your property with Echidna.
+
+## Solution
+
+This solution can be found in [exercises/exercise5/solution.sol](./exercises/exercise5/solution.sol)
+
+[ctf]: https://www.damnvulnerabledefi.xyz/
+
+<details>
+<summary>Solution Explained (spoilers ahead)</summary>
+
+The goal of the unstoppable challenge is to realize that `UnstoppableLender` has two modes of tracking its balance: `poolBalance` and `damnValuableToken.balanceOf(address(this))`.
+
+`poolBalance` is added to when someone calls `depositTokens()`.
+
+However, a user can call `damnValuableToken.transfer()` directly and increase the `balanceOf(address(this))` without increasing `poolBalance`.
+
+Now, the two balance trackers are out-of-sync.
+
+When Echidna calls `pool.flashLoan(10)`, the assertion `assert(poolBalance == balanceBefore)` in `UnstoppableLender` will break and the pool can no longer provide flash loans.
+
+See example output below from Echidna:
+
+```bash
+No output :(
+```
+</details>

--- a/program-analysis/echidna/Exercise-6.md
+++ b/program-analysis/echidna/Exercise-6.md
@@ -1,0 +1,57 @@
+# Exercise 6
+
+**Table of contents:**
+
+- [Exercise 6](#exercise-6)
+  - [Setup](#setup)
+  - [Exercise](#exercise)
+  - [Solution](#solution)
+
+Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum
+
+## Setup
+
+1. Follow the instructions on the [Damn Vulnerable DeFi CTF][ctf] page, namely:
+    - clone the repo, and
+    - install the dependencies.
+2. Create a contract called `TestNaiveReceiverEchidna` in the `contracts/naive-receiver` directory.
+3. Analyze the `before` function in `test/naive-receiver/naive-receiver.challenge.js` to identify what initial setup needs to be done.
+
+Hint: You don't need to make the setup very complex. It is possible to find the bug by examining just two contracts:
+  - `FlashLoanReceiver`
+  - `NaiveReceiverLenderPool.sol`
+
+No skeleton will be provided for this exercise.
+
+## Goals
+
+- Setup the testing environment with the right contracts and necessary balances.
+- Add a property to check whether the balance of the `FlashLoanReceiver` contract can change.
+- Create a `config.yaml` with the necessary configuration option(s).
+- Once Echidna finds the bug, fix the issue, and re-try your property with Echidna.
+
+## Solution
+
+This solution can be found in [exercises/exercise6/solution.sol](./exercises/exercise6/solution.sol)
+
+[ctf]: https://www.damnvulnerabledefi.xyz/
+
+<details>
+<summary>Solution Explained (spoilers ahead)</summary>
+
+The goal of the naive receiver challenge is to realize that an arbitrary user can call request a flash loan for `FlashLoanReceiver`.
+In fact, this can be done even if the arbitrary user has no ether.
+
+Echidna found this by simply calling `NaiveReceiverLenderPool.flashLoan()` with the address of `FlashLoanReceiver` and any arbitrary amount.
+
+See example output below from Echidna:
+
+```bash
+Analyzing contract: /Users/anishnaik/Documents/damn-vulnerable-defi/contracts/naive-receiver/NaiveReceiverEchidna.sol:NaiveReceiverEchidna
+echidna_test_contract_balance: failed!💥  
+  Call sequence:
+    flashLoan(0x62d69f6867a0a084c6d313943dc22023bc263691,353073667)
+```
+</details>
+
+

--- a/program-analysis/echidna/exercises/exercise5/config.yaml
+++ b/program-analysis/echidna/exercises/exercise5/config.yaml
@@ -1,0 +1,5 @@
+# The deployer and sender must be the same for this example.
+# The deployer is the 'attacker' and is sent INITIAL_ATTACKER_BALANCE
+deployer: '0x30000'
+# Sender must be the same so that it can use the attacker balance to try to break the invariant. 
+sender: ['0x30000']

--- a/program-analysis/echidna/exercises/exercise5/solution.sol
+++ b/program-analysis/echidna/exercises/exercise5/solution.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.8.0;
+
+import "./unstoppable/DamnValuableToken.sol";
+import "./unstoppable/UnstoppableLender.sol";
+import "./unstoppable/ReceiverUnstoppable.sol";
+
+/// @dev To run this contract: $ npx hardhat clean && npx hardhat compile --force && echidna-test . --contract UnstoppableEchidna --multi-abi --config contracts/unstoppable/config.yaml --test-limit 1000000
+contract UnstoppableEchidna {
+    // We will send ETHER_IN_POOL to the flash loan pool.
+    uint256 constant ETHER_IN_POOL = 1000000e18;
+    // We will send INITIAL_ATTACKER_BALANCE to the attacker (which is the deployer) of this contract.
+    uint256 constant INITIAL_ATTACKER_BALANCE = 100e18;
+
+    DamnValuableToken token;
+    UnstoppableLender pool;
+
+    // Setup echidna test by deploying the flash loan pool, approving it for token transfers, sending it tokens, and sending the attacker some tokens.
+    constructor() public payable {
+        token = new DamnValuableToken();
+        pool = new UnstoppableLender(address(token));
+        token.approve(address(pool), ETHER_IN_POOL);
+        pool.depositTokens(ETHER_IN_POOL);
+        token.transfer(msg.sender, INITIAL_ATTACKER_BALANCE);
+    }
+
+    // This is the callback function for flash loan receivers.
+    function receiveTokens(address tokenAddress, uint256 amount) external {
+        require(msg.sender == address(pool), "Sender must be pool");
+        // Return all tokens to the pool
+        require(
+            IERC20(tokenAddress).transfer(msg.sender, amount),
+            "Transfer of tokens failed"
+        );
+    }
+
+    // This is the Echidna property entrypoint.
+    // We want to test whether flash loans can always be made.
+    function echidna_testFlashLoan() public returns (bool) {
+        pool.flashLoan(10);
+        return true;
+    }
+}

--- a/program-analysis/echidna/exercises/exercise6/config.yaml
+++ b/program-analysis/echidna/exercises/exercise6/config.yaml
@@ -1,0 +1,2 @@
+# 10,000 ether is placed in the NaiveReceiverEchidna contract.
+balanceContract: 10000000000000000000000

--- a/program-analysis/echidna/exercises/exercise6/solution.sol
+++ b/program-analysis/echidna/exercises/exercise6/solution.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.8.0;
+
+import "./NaiveReceiverLenderPool.sol";
+import "./FlashLoanReceiver.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/// @dev To run this contract: $ npx hardhat clean && npx hardhat compile --force && echidna-test . --contract TestNaiveReceiverEchidna --multi-abi --config contracts/naive-receiver/config.yaml
+contract TestNaiveReceiverEchidna {
+    using Address for address payable;
+
+    // We will send ETHER_IN_POOL to the flash loan pool.
+    uint256 constant ETHER_IN_POOL = 1000e18;
+    // We will send ETHER_IN_RECEIVER to the flash loan receiver.
+    uint256 constant ETHER_IN_RECEIVER = 10e18;
+
+    NaiveReceiverLenderPool pool;
+    FlashLoanReceiver receiver;
+
+    // Setup echidna test by deploying the flash loan pool and receiver and sending them some ether.
+    constructor() payable {
+        pool = new NaiveReceiverLenderPool();
+        receiver = new FlashLoanReceiver(payable(address(pool)));
+        payable(address(pool)).sendValue(ETHER_IN_POOL);
+        payable(address(receiver)).sendValue(ETHER_IN_RECEIVER);
+    }
+
+    // We want to test whether the balance of the receiver contract can be decreased.
+    function echidna_test_contract_balance() public view returns (bool) {
+        return address(receiver).balance >= 10 ether;
+    }
+}


### PR DESCRIPTION
This is a continuation of PR #58 

Exercise 5 (unstoppable) - https://github.com/tinchoabbate/damn-vulnerable-defi/blob/v2.0.0/contracts/unstoppable/UnstoppableLender.sol:

- The unstoppable challenge is basically a flash loan pool that tracks token balances using two different methods. Thus, if you are able to transfer tokens directly to the pool, the assertion in `flashLoan` will break and you can prevent the pool from providing its flash loan service.
- Currently, the echidna test is unable to break the property. I set the test limit up to 3,000,000 and it does not seem to be able to break it. I looked at the coverage and the transfer() call is only attempted a few times here and there. Need @ggrieco-tob to review to see whether this warrants further investigation.

Exercise 6 (naive-receiver) - https://github.com/tinchoabbate/damn-vulnerable-defi/blob/v2.0.0/contracts/naive-receiver/NaiveReceiverLenderPool.sol:

- The naive-receiver challenge is also a flash loan pool that allows a user to request a flash loan for an arbitrary contract. Thus, you can drain a contract's balance without their consent.
- The echidna test breaks the property immediately. This is because it does not need to do any fancy exploration and the breaking case is pretty obvious. 

Remaining TODOS:
- Exercise 6 works but does not FULLY showcase the power of Echidna - there isn't too much exploration here. Thus, do we want to add the example? It is a good exercise in setting up the environment properly and using the `config.yaml` file.
- Exercise 5 is a better example of how Echidna does deep exploration but I am unable to break the property. The questions here are (1) is the property being tested correct and (2) if yes, what is a healthy test limit?