### PR TITLE
Update README.md

### DIFF
--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -47,7 +47,7 @@ docker run -it -v "$PWD":/home/training trailofbits/eth-security-toolbox
 Inside docker, run :
 
 ```bash
-solc-select 0.5.11
+solc-select use 0.5.11
 cd /home/training
 ```
 


### PR DESCRIPTION
`solc-select 0.5.11` returns an error: ` error: invalid choice: '0.5.11' (choose from 'install', 'use', 'versions')`