### PR TITLE
Add not-so-smart-contracts/cairo

### DIFF
--- a/not-so-smart-contracts/cairo/README.md
+++ b/not-so-smart-contracts/cairo/README.md
@@ -1,0 +1,27 @@
+# (Not So) Smart Contracts
+
+This repository contains examples of common Cairo smart contract vulnerabilities, including code from real smart contracts. Use Not So Smart Contracts to learn about Cairo vulnerabilities, as a reference when performing security reviews, and as a benchmark for security and analysis tools.
+
+## Features
+
+Each _Not So Smart Contract_ includes a standard set of information:
+
+* Description of the vulnerability type
+* Attack scenarios to exploit the vulnerability
+* Recommendations to eliminate or mitigate the vulnerability
+* Real-world contracts that exhibit the flaw
+* References to third-party resources with more information
+
+## Vulnerabilities
+
+| Not So Smart Contract | Description |
+| --- | --- |
+
+| [Improper access controls](access_controls) | Broken access controls due to StarkNet account abstraction |
+| [Integer division errors](integer_division) | Unexpected results due to division in a finite field |
+
+## Credits
+
+These examples are developed and maintained by [Trail of Bits](https://www.trailofbits.com/).
+
+If you have questions, problems, or just want to learn more, then join the #ethereum channel on the [Empire Hacking Slack](https://empireslacking.herokuapp.com/) or [contact us](https://www.trailofbits.com/contact/) directly.

--- a/not-so-smart-contracts/cairo/README.md
+++ b/not-so-smart-contracts/cairo/README.md
@@ -16,9 +16,11 @@ Each _Not So Smart Contract_ includes a standard set of information:
 
 | Not So Smart Contract | Description |
 | --- | --- |
-
 | [Improper access controls](access_controls) | Broken access controls due to StarkNet account abstraction |
 | [Integer division errors](integer_division) | Unexpected results due to division in a finite field |
+| [View state modifications](view_state) | View functions don't prevent state modifications |
+| [Arithmetic overflow](arithmetic_overflow) | Arithmetic in Cairo is not safe by default |
+| [Signature replays](replay_protection) | Account abstraction requires robust reuse protections |
 
 ## Credits
 

--- a/not-so-smart-contracts/cairo/access_controls/README.md
+++ b/not-so-smart-contracts/cairo/access_controls/README.md
@@ -1,0 +1,17 @@
+# Access controls & account abstraction
+
+The account abstraction model used by StarkNet has some important differences from what Solidity developers might be used to. There are no EOA addresses in StarkNet, only contract addresses. Rather than interact with contracts directly, users will usually deploy a contract that authenticates them and makes further calls on the user's behalf. At its simplest, this contract checks that the transaction is signed by the expected key, but it could also represent a multisig or DAO, or have more complex logic for what kinds of transactions it will allow (e.g. deposits and withdrawals could be handled by separate contracts or it could prevent unprofitable trades).
+
+It is still possible to interact with contracts directly. But from the perspective of the contract, the caller's address will be 0. Since 0 is also the default value for uninitialized storage, it's possible to accidentally construct access control checks that fail open instead of properly restricting access to only the intended users.
+
+## Attack Scenarios
+
+
+
+## Mitigations
+
+- Add zero address checks. Note that this will prevent users from interacting with the contract directly.
+
+## Examples
+
+- An [issue](https://github.com/OpenZeppelin/cairo-contracts/issues/148) in the ERC721 implementation included in a pre-0.1.0 version of OpenZeppelin's Cairo contract library would have allowed unapproved user to transfer tokens.

--- a/not-so-smart-contracts/cairo/access_controls/README.md
+++ b/not-so-smart-contracts/cairo/access_controls/README.md
@@ -4,14 +4,37 @@ The account abstraction model used by StarkNet has some important differences fr
 
 It is still possible to interact with contracts directly. But from the perspective of the contract, the caller's address will be 0. Since 0 is also the default value for uninitialized storage, it's possible to accidentally construct access control checks that fail open instead of properly restricting access to only the intended users.
 
-## Attack Scenarios
+## Example
 
+Consider the following two functions that both allow a user to claim a small amount of tokens. The first, without any checks, will end up sending tokens to the zero address, effectively burning them by removing them from the circlating supply. The latter will ensure that this cannot happen.
 
+```cairo
+@external
+func bad_claim_tokens{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    let (user) = get_caller_address()
+
+    let (user_current_balance) = user_balances.read(sender_address)
+    user_balances.write(user_current_balance + 200)
+
+    return ()
+end
+
+@external
+func better_claim_tokens{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    let (user) = get_caller_address()
+    assert_not_equal(user,0)
+
+    let (user_current_balance) = user_balances.read(sender_address)
+    user_balances.write(user, user_current_balance + 200)
+
+    return ()
+end
+```
 
 ## Mitigations
 
 - Add zero address checks. Note that this will prevent users from interacting with the contract directly.
 
-## Examples
+## External Examples
 
-- An [issue](https://github.com/OpenZeppelin/cairo-contracts/issues/148) in the ERC721 implementation included in a pre-0.1.0 version of OpenZeppelin's Cairo contract library would have allowed unapproved user to transfer tokens.
+- An [issue](https://github.com/OpenZeppelin/cairo-contracts/issues/148) in the ERC721 implementation included in a pre-0.1.0 version of OpenZeppelin's Cairo contract library would have allowed unapproved users to transfer tokens.

--- a/not-so-smart-contracts/cairo/arithmetic_overflow/README.md
+++ b/not-so-smart-contracts/cairo/arithmetic_overflow/README.md
@@ -1,0 +1,16 @@
+# Arithmetic overflow
+
+The default primitive type, the felt or field element, behaves a lot like an integer does in any other language but it has a few important differences to keep in mind. The range of valid felt values is (-P/2,P/2). P here is the prime used by Cairo, which is current a 252-bit number. Arithemtic using felts is unchecked for overflow and can lead to unexpected results if this isn't properly accounted for. And since the range of values spans both negative and positive values, things like multiplying two positive numbers can have a negative value as a result, and vice versa, multiplying a two negative numbers doesn't always have a positive result.
+
+StarkNet also provides the Uint256 module which offers a more typical 256-bit integer to developers. However, the arithmetic provided by this module is also unchecked so overflow is still something to keep in mind. For more robust integer support, consider using SafeMath from OpenZeppelin's Contracts for Cairo.
+
+## Attack Scenarios
+
+
+
+## Mitigations
+
+- Always add checks for overflow when working with felts or Uint256s directly.
+- Consider using the [OpenZeppelin Contracts for Cairo's SafeMath functions](https://github.com/OpenZeppelin/cairo-contracts/blob/main/src/openzeppelin/security/safemath.cairo) instead of doing arithmetic directly
+
+## Examples

--- a/not-so-smart-contracts/cairo/integer_division/README.md
+++ b/not-so-smart-contracts/cairo/integer_division/README.md
@@ -1,0 +1,15 @@
+# Integer Division
+
+Math in Cairo is done in a finite field, which is why the numeric type is called `felt`, for field elements. In most cases addition, subtraction and multiplication will behave as they would in standard integer operations when writing Cairo code. However, developers need to pay a little bit extra attention when performing division. Unlike in Solidity, where division is carried out as if the values were real numbers and anything after the decimal place is truncated, in Cairo it's more intuitive to think of division as the inverse of multiplication. When a number divides a whole number of times into another number, the result is what we would expect, for example 30/6=5. But if we try to divide numbers that don't quite match up so perfectly, like 30/9, the result can be a bit surprising, in this case 1206167596222043737899107594365023368541035738443865566657697352045290673497. That's because 120...97 * 9  = 30 (modulo the [252-bit prime used by StarkNet](https://docs.starkware.co/starkex-v4/crypto/stark-curve))
+
+## Attack Scenarios
+
+
+## Mitigations
+
+- Review which numeric type is most appropriate for your use case. Especially if your programs rely on division, consider using [the uint256 module](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/uint256.cairo) instead of the felt primitive type.
+
+## Examples
+
+- In [incorrect_division_1](incorrect_division_1.cairo), we give both unsafe and safe examples of
+the division operation.

--- a/not-so-smart-contracts/cairo/integer_division/README.md
+++ b/not-so-smart-contracts/cairo/integer_division/README.md
@@ -2,14 +2,34 @@
 
 Math in Cairo is done in a finite field, which is why the numeric type is called `felt`, for field elements. In most cases addition, subtraction and multiplication will behave as they would in standard integer operations when writing Cairo code. However, developers need to pay a little bit extra attention when performing division. Unlike in Solidity, where division is carried out as if the values were real numbers and anything after the decimal place is truncated, in Cairo it's more intuitive to think of division as the inverse of multiplication. When a number divides a whole number of times into another number, the result is what we would expect, for example 30/6=5. But if we try to divide numbers that don't quite match up so perfectly, like 30/9, the result can be a bit surprising, in this case 1206167596222043737899107594365023368541035738443865566657697352045290673497. That's because 120...97 * 9  = 30 (modulo the [252-bit prime used by StarkNet](https://docs.starkware.co/starkex-v4/crypto/stark-curve))
 
-## Attack Scenarios
+## Example
 
+Consider the following functions that normalize a user's token balance to a human readable value for a token with 10^18 decimals. In the first function, it will only provide meaningful values if a user has a whole number of tokens and return non-sense values in every other case. The better version stores these values as Uint256s and uses more traditional integer division. 
+
+```cairo
+@external
+func bad_normalize_tokens{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (normalized_balance : felt):
+    let (user) = get_caller_address()
+
+    let (user_current_balance) = user_balances.read(user)
+    let (normalized_balance) = user_current_balance / 10**18
+
+    return (normalized_balance)
+end
+
+@external
+func better_normalize_tokens{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (normalized_balance : Uint256):
+    let (user) = get_caller_address()
+
+    let (user_current_balance) = user_balances.read(user)
+    let (normalized_balance, _) = uint256_unsigned_div_rem(user_current_balance, 10**18)
+
+    return (normalized_balance)
+end
+```
 
 ## Mitigations
 
 - Review which numeric type is most appropriate for your use case. Especially if your programs rely on division, consider using [the uint256 module](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/uint256.cairo) instead of the felt primitive type.
 
-## Examples
-
-- In [incorrect_division_1](incorrect_division_1.cairo), we give both unsafe and safe examples of
-the division operation.
+## External Examples

--- a/not-so-smart-contracts/cairo/replay_protection/README.md
+++ b/not-so-smart-contracts/cairo/replay_protection/README.md
@@ -1,0 +1,14 @@
+# Signature replay protection
+
+The StarkNet account abstraction model allows a lot of the details of authentication to be offloaded to contracts. This provides a greater amount of flexibility, but that also means signature schemas need to be constructed with great care. Signatures must be resilient to replay attacks and signature malleability. Signatures must include a nonce and should have a domain separator to bind the signature to a particular contract and chain, so for example testnet signatures can't be replayed against mainnet contracts.
+
+## Attack Scenarios
+
+
+
+## Mitigations
+
+- Consider using the [OpenZeppelin Contracts for Cairo Account contract](https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Account.md) or another existing account contract implementation.
+
+## Examples
+

--- a/not-so-smart-contracts/cairo/replay_protection/README.md
+++ b/not-so-smart-contracts/cairo/replay_protection/README.md
@@ -2,13 +2,17 @@
 
 The StarkNet account abstraction model allows a lot of the details of authentication to be offloaded to contracts. This provides a greater amount of flexibility, but that also means signature schemas need to be constructed with great care. Signatures must be resilient to replay attacks and signature malleability. Signatures must include a nonce and should have a domain separator to bind the signature to a particular contract and chain, so for example testnet signatures can't be replayed against mainnet contracts.
 
-## Attack Scenarios
+## Example
 
+Consider the following function that validates a signature for EIP712-style permit functionality. The first version includes neither a nonce, nor a way of identifying the specific chain a signature is for. This signature schema would allow signatures to be replayed both on the same chain, but also across chains, for example between a testnet and mainnet.
 
+```cairo
+    # TODO
+```
 
 ## Mitigations
 
 - Consider using the [OpenZeppelin Contracts for Cairo Account contract](https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Account.md) or another existing account contract implementation.
 
-## Examples
+## External Examples
 

--- a/not-so-smart-contracts/cairo/view_state/README.md
+++ b/not-so-smart-contracts/cairo/view_state/README.md
@@ -1,0 +1,13 @@
+# State modifications in a view function
+
+StarkNet provides the @view decorator to signal that a function should not make state modifications. However, this is [not currently enforced by the compiler](https://starknet.io/docs/hello_starknet/intro.html). Developers should take care when designing view functions but also when calling functions in other contracts as they may result in unexpected behavior if they do include state modifications accidentally.
+
+## Attack Scenarios
+
+
+
+## Mitigations
+
+- Carefully review all `@view` functions, including those called in 3rd party contracts, to ensure they don't modify state unexpectedly.
+
+## Examples

--- a/not-so-smart-contracts/cairo/view_state/README.md
+++ b/not-so-smart-contracts/cairo/view_state/README.md
@@ -2,12 +2,23 @@
 
 StarkNet provides the @view decorator to signal that a function should not make state modifications. However, this is [not currently enforced by the compiler](https://starknet.io/docs/hello_starknet/intro.html). Developers should take care when designing view functions but also when calling functions in other contracts as they may result in unexpected behavior if they do include state modifications accidentally.
 
-## Attack Scenarios
+## Example
 
+Consider the following function that's declared as a `@view`. It may have originally been intended as an actual view function but was later repurposed to fetch a nonce _and also increment it in the process_ to ensure a nonce is never repeated when building a signature. 
 
+```cairo
+@view
+func bad_get_nonce{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (nonce : felt):
+    let (user) = get_caller_address()
+    let (nonce) = user_nonces.read(user)
+    user_nonces.write(user, nonce + 1)
+
+    return (nonce)
+end
+```
 
 ## Mitigations
 
 - Carefully review all `@view` functions, including those called in 3rd party contracts, to ensure they don't modify state unexpectedly.
 
-## Examples
+## External Examples


### PR DESCRIPTION
Adds some initial examples for Cairo in the style of [Not-So-Smart-Contracts](https://github.com/crytic/not-so-smart-contracts).