### PR TITLE
Solving the level is not possible without knowing the available config options

### DIFF
--- a/program-analysis/echidna/Exercise-5.md
+++ b/program-analysis/echidna/Exercise-5.md
@@ -36,7 +36,8 @@ Only the following contracts are relevant:
 
 We recommend to first try without reading the following hints. The hints are in the [`hints` branch](https://github.com/crytic/damn-vulnerable-defi-echidna/tree/hints).
 
-- The invariant that we are looking for is "the balance of the receiver contract can not decrease"
+- Remember that sometimes you have to supply the test contract with Ether. Read more in [the Echidna wiki](https://github.com/crytic/echidna/wiki/Config) and look at [the default config setup](https://github.com/crytic/echidna/blob/master/tests/solidity/basic/default.yaml).
+- The invariant that we are looking for is "the balance of the receiver contract can not decrease" 
 - Read what is the [multi abi option](https://github.com/crytic/building-secure-contracts/blob/master/program-analysis/echidna/common-testing-approaches.md#external-testing)
 - A template is provided in [contracts/naive-receiver/NaiveReceiverEchidna.sol](https://github.com/crytic/damn-vulnerable-defi-echidna/blob/hints/contracts/naive-receiver/NaiveReceiverEchidna.sol)
 - A config file is provided in [naivereceiver.yaml](https://github.com/crytic/damn-vulnerable-defi-echidna/blob/hints/naivereceiver.yaml)


### PR DESCRIPTION
My biggest struggle with this level was passing the `echidna-test: Deploying the contract 0x00a329c0648769A73afAc7F9381E08FB43dBEA72 failed (revert, out-of-gas, sending ether to an non-payable constructor, etc.)` error. 

It is caused by not passing the initial Ether to the test contract via `balanceContract` in the config file. 

This is pretty obvious to me now, but I think I either missed it while reviewing the materials, or it wasn't showcased.

This PR:
- adds a small hint that will guide the person to explore the available config options on their own and does not spoil the solution