### PR TITLE
Exercise 5 and 6 names were swapped

### DIFF
--- a/program-analysis/echidna/README.md
+++ b/program-analysis/echidna/README.md
@@ -31,8 +31,8 @@ Watch our [Fuzzing workshop](https://www.youtube.com/watch?v=QofNQxW_K08&list=PL
   - [Exercise 2](./Exercise-2.md): Testing access control
   - [Exercise 3](./Exercise-3.md): Testing with custom initialization
   - [Exercise 4](./Exercise-4.md): Testing with `assert`
-  - [Exercise 5](./Exercise-5.md): Solving Damn Vulnerable DeFi - Unstoppable
-  - [Exercise 6](./Exercise-6.md): Solving Damn Vulnerable DeFi - Naive Receiver
+  - [Exercise 5](./Exercise-5.md): Solving Damn Vulnerable DeFi - Naive Receiver
+  - [Exercise 6](./Exercise-6.md): Solving Damn Vulnerable DeFi - Unstoppable
   - [Exercise 7](./Exercise-7.md): Solving Damn Vulnerable DeFi - Side Entrance
   - [Exercise 8](./Exercise-8.md): Solving Damn Vulnerable DeFi - The Rewarder
 


### PR DESCRIPTION
This PR fixes the names of exercises 5 and 6.

The names were already fixed in #148 but were overridden by accident in #143.

With this PR, they will return to the state from #148.

