### PR TITLE
Fix for Slither exercise 1

### DIFF
--- a/program-analysis/slither/exercises/exercise1/solution.py
+++ b/program-analysis/slither/exercises/exercise1/solution.py
@@ -9,6 +9,7 @@ for contract in slither.contracts:
    if coin in contract.inheritance:
       # Get the function definition  
       mint = contract.get_function_from_signature('_mint(address,uint256)')
-      # If the function was not declarer by coin, there is a bug !  
-      if mint.contract != coin:
+      # If the function was not declared by coin, there is a bug !
+      # Detect error only for contracts overriding the '_mint' function
+      if mint.contract_declarer == contract:
            print(f'Error, {contract} overrides {mint}')


### PR DESCRIPTION
Current solution is checking for `mint.contract` that seems to always return the current contract.
As a result, it returns an error for any contract that inherits from `Coin`, even if it does not override `_mint`.
It also returns an error for contracts inheriting from a contract overriding `_mint` (see issue #10) even if they don't override `_mint` themselves.

Fixes #10.