### PR TITLE
Install Ganache globally

### DIFF
--- a/program-analysis/echidna/end-to-end-testing.md
+++ b/program-analysis/echidna/end-to-end-testing.md
@@ -27,13 +27,13 @@ $ npm i truffle
 If `ganache` is not installed, add it manually. In our example, we will run: 
 
 ```
-$ npm i ganache
+$ npm -g i ganache
 ```
 
 Other projects using yarn will require:
 
 ```
-$ yarn add ganache
+$ yarn global add ganache
 ```
 
 Ensure that `$ ganache --version` outputs `ganache v7.3.2` or greater.


### PR DESCRIPTION
I couldn't get Etheno to work with Ganache installed on the project level. 

It works when installed globally. 

This PR:
- adds appropriate flags to Ganache installation commands to make it available globally

As I am not sure if it is a good practice to install npm packages globally, feedback would be appreciated ✌🏼

Thanks! 