### PR TITLE
ci: echidna: temporarily use latest stable version

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -162,7 +162,7 @@ jobs:
         output-file: ${{ matrix.files }}.out
         solc-version: ${{ matrix.solc-version || '0.5.11' }}
         echidna-workdir: ${{ matrix.workdir }}
-        echidna-version: edge
+        echidna-version: latest
         crytic-args: ${{ matrix.crytic-args || '' }}
 
     - name: Verify that the exit code is correct


### PR DESCRIPTION
There's an issue parsing Hardhat projects in the `edge` containers at this time, due to crytic/crytic-compile#364. This change should be reverted once a new crytic-compile release is produced.