### PR TITLE
docs: typo fix

### DIFF
--- a/program-analysis/echidna/assertion-checking.md
+++ b/program-analysis/echidna/assertion-checking.md
@@ -44,7 +44,7 @@ contract Incrementor {
 }
 ```
 
-We could also use a special event called `AssertionFailed` with any number of parameters to let Echidna know about a failed assertion without using `assert`. This will works in any contract. For instance:
+We could also use a special event called `AssertionFailed` with any number of parameters to let Echidna know about a failed assertion without using `assert`. This will work in any contract. For instance:
 
 ```solidity
 contract Incrementor {


### PR DESCRIPTION
This PR:
- fixes a small typo in the word "work".