### PR TITLE
docs: fix value boundary

### DIFF
--- a/program-analysis/echidna/property-creation.md
+++ b/program-analysis/echidna/property-creation.md
@@ -162,7 +162,7 @@ We want Echidna to spend most of the execution exploring the contract to test. S
 ```solidity
   function depositShares_never_reverts(uint256 val) public {
     if(token.balanceOf(address(this)) > 0) {
-      val = val % token.balanceOf(address(this));
+      val = val % (token.balanceOf(address(this)) + 1);
       try c.depositShares(val) { /* not reverted */ } catch { assert(false); }
       assert(c.getShares(address(this)) > 0);
     } else {


### PR DESCRIPTION
Isn't the boundary `val = val % token.balanceOf(address(this))` missing the maximal value of `token.balanceOf(address(this))`?

In the [Learn how to fuzz like a pro: Intro to AMM's invariants](https://youtu.be/n0RaKKVTGvA?t=4738), Justin creates a helper function to create a boundary on the `amount`. 

It looks like this:
```solidity
function _between(
        uint256 amount,
        uint256 low,
        uint256 high
    ) internal pure returns (uint256) {
        return (low + (amount % (high - low + 1)));
    }
```

`+1` is added to include the maximal value that can be sent. 

As explained in [this video on the modulo operator by Golan Levin](https://www.youtube.com/watch?v=r5Iy3v1co0A&t=159s), the modulo operator:
| mod | remainder |
| --- | --- |
| 5%5|0|
|6%5|1|
|7%5|2|
|8%5|3|
|9%5|4|
|10%5|0|
|11%5|1|
...

and the cycle repeats

So in our case 
| mod | remainder |
| --- | --- |
| val % token.balanceOf(address(this)) | token.balanceOf(address(this)) -1 |

So we have to add `+1` to cover the gap.