### PR TITLE
Fix broken links in Echidna markdown files

### DIFF
--- a/program-analysis/echidna/Exercise-1.md
+++ b/program-analysis/echidna/Exercise-1.md
@@ -2,8 +2,8 @@
 
 **Table of contents:**
 
-- [Targeted contract](#Targeted-contract)
-- [Exercise](#exercise)
+- [Targeted contract](#targeted-contract)
+- [Exercise](#testing-a-token-balance)
 - [Solution](#solution)
 
 Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum

--- a/program-analysis/echidna/Exercise-2.md
+++ b/program-analysis/echidna/Exercise-2.md
@@ -5,7 +5,7 @@ This exercise requires to finish the [exercise 1](Exercise-1.md).
 **Table of contents:**
 
 - [Targeted contract](#targeted-contract)
-- [Exercise](#exercice)
+- [Exercise](#testing-access-control)
 - [Solution](#solution)
 
 Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum

--- a/program-analysis/echidna/Exercise-3.md
+++ b/program-analysis/echidna/Exercise-3.md
@@ -5,7 +5,7 @@ This exercise requires to finish [exercise 1](./Exercise-1.md) and [exercise 2](
 **Table of contents:**
 
 - [Targeted contract](#targeted-contract)
-- [Exercise](#exercice)
+- [Exercise](#testing-with-custom-initialization)
 - [Solution](#solution)
 
 Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum

--- a/program-analysis/echidna/Exercise-4.md
+++ b/program-analysis/echidna/Exercise-4.md
@@ -12,7 +12,7 @@ Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum
 
 ## Targeted contract
 
-We will test the following contract *[exercises/token.sol](exercises/token.sol)*:
+We will test the following contract *[exercises/exercise4/token.sol](exercises/exercise4/token.sol)*:
 
 ```Solidity
  contract Ownership{

--- a/program-analysis/echidna/Exercise-7.md
+++ b/program-analysis/echidna/Exercise-7.md
@@ -4,7 +4,7 @@
 
 - [Exercise 7](#exercise-7)
   - [Setup](#setup)
-  - [Exercise](#exercise)
+  - [Goals](#goals)
   - [Solution](#solution)
 
 Join the team on Slack at: https://empireslacking.herokuapp.com/ #ethereum

--- a/program-analysis/echidna/Exercise-8.md
+++ b/program-analysis/echidna/Exercise-8.md
@@ -40,7 +40,7 @@ We recommend to first try without reading the following hints. The hints are in 
 - The invariant that we are looking for is "an attacker cannot get almost whole amount of rewards"
 - Read what is the [multi abi option](https://github.com/crytic/building-secure-contracts/blob/master/program-analysis/echidna/common-testing-approaches.md#external-testing)
 - A template is provided in [contracts/the-rewarder/EchidnaRewarder.sol](https://github.com/crytic/damn-vulnerable-defi-echidna/blob/hints/contracts/the-rewarder/EchidnaRewarder.sol)
-- A config file is provided in [the-rewarder.yaml](https://github.com/crytic/damn-vulnerable-defi-echidna/blob/hints/the-rewarder.yaml)
+- A config file is provided in [the-rewarder.yaml](https://github.com/crytic/damn-vulnerable-defi-echidna/blob/solutions/the-rewarder.yaml)
 
 ## Solution
 

--- a/program-analysis/echidna/frequently_asked_questions.md
+++ b/program-analysis/echidna/frequently_asked_questions.md
@@ -56,7 +56,7 @@ Coverage per isolated transaction will be possible, however, it is incomplete vi
 
 ## How to know which type of testing should be used? (boolean properties, assertions, etc)
 
-Check the [tutorial on selecting the right test mode](https://github.com/crytic/building-secure-contracts/edit/dev-internal-asserts/program-analysis/echidna/testing-modes.md)
+Check the [tutorial on selecting the right test mode](testing-modes.md)
 
 ## Why does Echidna return “Property X failed with no transactions made” when running one or more tests?
 

--- a/program-analysis/echidna/fuzzing_tips.md
+++ b/program-analysis/echidna/fuzzing_tips.md
@@ -2,8 +2,8 @@
 
 The following describe fuzzing tips to make Echidna more efficient:
 
-- **To filter the values range of inputs, use `%`**. See [Filtering inputs](#filtering_inputs).
-- **When dynamic arrays are needed, use push/pop**. See [Dealing with dynamic arrays](#dealing_with_dynamic_arrays).
+- **To filter the values range of inputs, use `%`**. See [Filtering inputs](#filtering-inputs).
+- **When dynamic arrays are needed, use push/pop**. See [Dealing with dynamic arrays](#dealing-with-dynamic-arrays).
 
 ## Filtering inputs
 

--- a/program-analysis/echidna/property-creation.md
+++ b/program-analysis/echidna/property-creation.md
@@ -5,7 +5,7 @@
 - [Introduction](#introduction)
 - [A first approach](#a-first-approach)
 - [Enhacing postcondition checks](#enhacing-postcondition-checks)
-- [Combining properties](combining-properties)
+- [Combining properties](#combining-properties)
 - [Summary: How to write good properties](#summary-how-to-write-good-properties)
 
 ## Introduction

--- a/program-analysis/echidna/testing-bytecode.md
+++ b/program-analysis/echidna/testing-bytecode.md
@@ -5,8 +5,8 @@
 - [Proxy pattern](#proxy-pattern)
 - [Run Echidna](#run-echidna)
 - [Differential fuzzing](#differential-fuzzing)
-- [Generic proxy pattern](#generic-proxy-pattern)
-- [Summary: Testing bytecode](#summary-testing-bytecode)
+- [Generic proxy pattern](#generic-proxy-code)
+- [Summary: Testing bytecode](#summary-testing-contracts-without-source-code)
 
 ## Introduction
 


### PR DESCRIPTION
Fixes #200 
Echidna exercise 8 has no hint in the `damn-vulnerable-defi-echidna` repo, will update the link when it's fixed (so far will be broken)