### PR TITLE
Learn evm expansion

### DIFF
--- a/learn_evm/README.md
+++ b/learn_evm/README.md
@@ -2,9 +2,10 @@
 
 List of EVM technical knowledge 
 
+- [EVM Opcode Reference](evm_opcodes.md): Reference and notes for each of the EVM opcodes
+- [Transaction Tracing](tracing.md): Helper scripts and guidance for generating and navigating transaction traces
+- [Yellow Paper Guidance](yellow-paper.md): Symbol reference for more easily reading the Ethereum yellow paper
 - [Forks <> EIPs](eips_forks.md): Summarize the EIPs included in each fork
   - [Forks <> CIPs](cips_forks.md): Summarize the CIPs and EIPs included in each Celo fork *(EVM-compatible chain)*
   - [Upgrades <> TIPs](tips_upgrades.md): Summarize the TIPs included in each TRON upgrade *(EVM-compatible chain)*
   - [Forks <> BEPs](beps_forks.md): Summarize the BEPs included in each BSC fork *(EVM-compatible chain)*
-- [Yellow Paper Guidance](yellow-paper.md): Symbol reference for more easily reading the Ethereum yellow paper
-- [Transaction Tracing](tracing.md): Helper scripts and guidance for generating and navigating transaction traces

--- a/learn_evm/README.md
+++ b/learn_evm/README.md
@@ -6,3 +6,5 @@ List of EVM technical knowledge
   - [Forks <> CIPs](cips_forks.md): Summarize the CIPs and EIPs included in each Celo fork *(EVM-compatible chain)*
   - [Upgrades <> TIPs](tips_upgrades.md): Summarize the TIPs included in each TRON upgrade *(EVM-compatible chain)*
   - [Forks <> BEPs](beps_forks.md): Summarize the BEPs included in each BSC fork *(EVM-compatible chain)*
+- [Yellow Paper Guidance](yellow-paper.md): Symbol reference for more easily reading the Ethereum yellow paper
+- [Transaction Tracing](tracing.md): Helper scripts and guidance for generating and navigating transaction traces

--- a/learn_evm/evm_opcodes.md
+++ b/learn_evm/evm_opcodes.md
@@ -14,203 +14,1191 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 
 | Opcode | Name | Description | Extra Info | Gas |
 | --- | --- | --- | --- | --- |
-| `0x00` | STOP | Halts execution | - | 0 |
-| `0x01` | ADD | Addition operation | - | 3 |
-| `0x02` | MUL | Multiplication operation | - | 5 |
-| `0x03` | SUB | Subtraction operation | - | 3 |
-| `0x04` | DIV | Integer division operation | - | 5 |
-| `0x05` | SDIV | Signed integer division operation (truncated) | - | 5 |
-| `0x06` | MOD | Modulo remainder operation | - | 5 |
-| `0x07` | SMOD | Signed modulo remainder operation | - | 5 |
-| `0x08` | ADDMOD | Modulo addition operation | - | 8 |
-| `0x09` | MULMOD | Modulo multiplication operation | - | 8 |
-| `0x0a` | EXP | Exponential operation | - | 10* |
-| `0x0b` | SIGNEXTEND | Extend length of two's complement signed integer | - | 5 |
-| `0x0c` - `0x0f` | Unused | Unused | - |
-| `0x10` | LT | Less-than comparison | - | 3 |
-| `0x11` | GT | Greater-than comparison | - | 3 |
-| `0x12` | SLT | Signed less-than comparison | - | 3 |
-| `0x13` | SGT | Signed greater-than comparison | - | 3 |
-| `0x14` | EQ | Equality comparison | - | 3 |
-| `0x15` | ISZERO | Simple not operator | - | 3 |
-| `0x16` | AND | Bitwise AND operation | - | 3 |
-| `0x17` | OR | Bitwise OR operation | - | 3 |
-| `0x18` | XOR | Bitwise XOR operation | - | 3 |
-| `0x19` | NOT | Bitwise NOT operation | - | 3 |
-| `0x1a` | BYTE | Retrieve single byte from word | - | 3 |
-| `0x1b` | SHL | Shift Left | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
-| `0x1c` | SHR | Logical Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
-| `0x1d` | SAR | Arithmetic Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
-| `0x20` | KECCAK256 | Compute Keccak-256 hash | - | 30* |
-| `0x21` - `0x2f`| Unused | Unused |
-| `0x30` | ADDRESS | Get address of currently executing account | - | 2 |
-| `0x31` | BALANCE | Get balance of the given account | - | 700 |
-| `0x32` | ORIGIN | Get execution origination address | - | 2 |
-| `0x33` | CALLER | Get caller address | - | 2 |
-| `0x34` | CALLVALUE | Get deposited value by the instruction/transaction responsible for this execution | - | 2 |
-| `0x35` | CALLDATALOAD | Get input data of current environment | - | 3 |
-| `0x36` | CALLDATASIZE | Get size of input data in current environment | - | 2* |
-| `0x37` | CALLDATACOPY | Copy input data in current environment to memory | - | 3 |
-| `0x38` | CODESIZE | Get size of code running in current environment | - | 2 |
-| `0x39` | CODECOPY | Copy code running in current environment to memory | - | 3* |
-| `0x3a` | GASPRICE | Get price of gas in current environment | - | 2 |
-| `0x3b` | EXTCODESIZE | Get size of an account's code | - | 700 |
-| `0x3c` | EXTCODECOPY | Copy an account's code to memory | - | 700* |
-| `0x3d` | RETURNDATASIZE | Pushes the size of the return data buffer onto the stack | [EIP 211](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-211.md) | 2 |
-| `0x3e` | RETURNDATACOPY | Copies data from the return data buffer to memory | [EIP 211](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-211.md) | 3 |
-| `0x3f` | EXTCODEHASH | Returns the keccak256 hash of a contract's code | [EIP 1052](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md) | 700 |
-| `0x40` | BLOCKHASH | Get the hash of one of the 256 most recent complete blocks | - | 20 |
-| `0x41` | COINBASE | Get the block's beneficiary address | - | 2 |
-| `0x42` | TIMESTAMP | Get the block's timestamp | - | 2 |
-| `0x43` | NUMBER | Get the block's number | - | 2 |
-| `0x44` | DIFFICULTY | Get the block's difficulty | - | 2 |
-| `0x45` | GASLIMIT | Get the block's gas limit | - | 2 |
-| `0x46` | CHAINID | Returns the current chain’s EIP-155 unique identifier | [EIP 1344](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md) | 2 |
-| `0x47` - `0x4f` | Unused | - |
-| `0x48` | BASEFEE | Returns the value of the base fee of the current block it is executing in. | [EIP 3198](https://eips.ethereum.org/EIPS/eip-3198) | 2 |
-| `0x50` | POP | Remove word from stack | - | 2 |
-| `0x51` | MLOAD | Load word from memory | - | 3* |
-| `0x52` | MSTORE | Save word to memory | - | 3* |
-| `0x53` | MSTORE8 | Save byte to memory | - | 3 |
-| `0x54` | SLOAD | Load word from storage | - | 800 |
-| `0x55` | SSTORE | Save word to storage | - | 20000** |
-| `0x56` | JUMP | Alter the program counter | - | 8 |
-| `0x57` | JUMPI | Conditionally alter the program counter | - | 10 |
-| `0x58` | GETPC | Get the value of the program counter prior to the increment | - | 2 |
-| `0x59` | MSIZE | Get the size of active memory in bytes | - | 2 |
-| `0x5a` | GAS | Get the amount of available gas, including the corresponding reduction for the cost of this instruction | - | 2 |
-| `0x5b` | JUMPDEST | Mark a valid destination for jumps | - | 1 |
-| `0x5c` - `0x5f` | Unused | - |
-| `0x60` | PUSH1 | Place 1 byte item on stack | - | 3 |
-| `0x61` | PUSH2 | Place 2-byte item on stack | - | 3 |
-| `0x62` | PUSH3 | Place 3-byte item on stack | - | 3 |
-| `0x63` | PUSH4 | Place 4-byte item on stack | - | 3 |
-| `0x64` | PUSH5 | Place 5-byte item on stack | - | 3 |
-| `0x65` | PUSH6 | Place 6-byte item on stack | - | 3 |
-| `0x66` | PUSH7 | Place 7-byte item on stack | - | 3 |
-| `0x67` | PUSH8 | Place 8-byte item on stack | - | 3 |
-| `0x68` | PUSH9 | Place 9-byte item on stack | - | 3 |
-| `0x69` | PUSH10 | Place 10-byte item on stack | - | 3 |
-| `0x6a` | PUSH11 | Place 11-byte item on stack | - | 3 |
-| `0x6b` | PUSH12 | Place 12-byte item on stack | - | 3 |
-| `0x6c` | PUSH13 | Place 13-byte item on stack | - | 3 |
-| `0x6d` | PUSH14 | Place 14-byte item on stack | - | 3 |
-| `0x6e` | PUSH15 | Place 15-byte item on stack | - | 3 |
-| `0x6f` | PUSH16 | Place 16-byte item on stack | - | 3 |
-| `0x70` | PUSH17 | Place 17-byte item on stack | - | 3 |
-| `0x71` | PUSH18 | Place 18-byte item on stack | - | 3 |
-| `0x72` | PUSH19 | Place 19-byte item on stack | - | 3 |
-| `0x73` | PUSH20 | Place 20-byte item on stack | - | 3 |
-| `0x74` | PUSH21 | Place 21-byte item on stack | - | 3 |
-| `0x75` | PUSH22 | Place 22-byte item on stack | - | 3 |
-| `0x76` | PUSH23 | Place 23-byte item on stack | - | 3 |
-| `0x77` | PUSH24 | Place 24-byte item on stack | - | 3 |
-| `0x78` | PUSH25 | Place 25-byte item on stack | - | 3 |
-| `0x79` | PUSH26 | Place 26-byte item on stack | - | 3 |
-| `0x7a` | PUSH27 | Place 27-byte item on stack | - | 3 |
-| `0x7b` | PUSH28 | Place 28-byte item on stack | - | 3 |
-| `0x7c` | PUSH29 | Place 29-byte item on stack | - | 3 |
-| `0x7d` | PUSH30 | Place 30-byte item on stack | - | 3 |
-| `0x7e` | PUSH31 | Place 31-byte item on stack | - | 3 |
-| `0x7f` | PUSH32 | Place 32-byte (full word) item on stack | - |  3 |
-| `0x80` | DUP1 | Duplicate 1st stack item | - |  3 |
-| `0x81` | DUP2 | Duplicate 2nd stack item | - | 3 |
-| `0x82` | DUP3 | Duplicate 3rd stack item | - | 3 |
-| `0x83` | DUP4 | Duplicate 4th stack item | - | 3 |
-| `0x84` | DUP5 | Duplicate 5th stack item | - | 3 |
-| `0x85` | DUP6 | Duplicate 6th stack item | - | 3 |
-| `0x86` | DUP7 | Duplicate 7th stack item | - | 3 |
-| `0x87` | DUP8 | Duplicate 8th stack item | - | 3 |
-| `0x88` | DUP9 | Duplicate 9th stack item | - | 3 |
-| `0x89` | DUP10 | Duplicate 10th stack item | - | 3 |
-| `0x8a` | DUP11 | Duplicate 11th stack item | - | 3 |
-| `0x8b` | DUP12 | Duplicate 12th stack item | - | 3 |
-| `0x8c` | DUP13 | Duplicate 13th stack item | - | 3 |
-| `0x8d` | DUP14 | Duplicate 14th stack item | - | 3 |
-| `0x8e` | DUP15 | Duplicate 15th stack item | - | 3 |
-| `0x8f` | DUP16 | Duplicate 16th stack item | - | 3 |
-| `0x90` | SWAP1 | Exchange 1st and 2nd stack items | - | 3 |
-| `0x91` | SWAP2 | Exchange 1st and 3rd stack items | - | 3 |
-| `0x92` | SWAP3 | Exchange 1st and 4th stack items | - | 3 |
-| `0x93` | SWAP4 | Exchange 1st and 5th stack items | - | 3 |
-| `0x94` | SWAP5 | Exchange 1st and 6th stack items | - | 3 |
-| `0x95` | SWAP6 | Exchange 1st and 7th stack items | - | 3 |
-| `0x96` | SWAP7 | Exchange 1st and 8th stack items | - | 3 |
-| `0x97` | SWAP8 | Exchange 1st and 9th stack items | - | 3 |
-| `0x98` | SWAP9 | Exchange 1st and 10th stack items | - | 3 |
-| `0x99` | SWAP10 | Exchange 1st and 11th stack items | - | 3 |
-| `0x9a` | SWAP11 | Exchange 1st and 12th stack items | - | 3 |
-| `0x9b` | SWAP12 | Exchange 1st and 13th stack items | - | 3 |
-| `0x9c` | SWAP13 | Exchange 1st and 14th stack items | - | 3 |
-| `0x9d` | SWAP14 | Exchange 1st and 15th stack items | - | 3 |
-| `0x9e` | SWAP15 | Exchange 1st and 16th stack items | - | 3 |
-| `0x9f` | SWAP16 | Exchange 1st and 17th stack items | - | 3 |
-| `0xa0` | LOG0 | Append log record with no topics | - | 375 |
-| `0xa1` | LOG1 | Append log record with one topic | - | 750 |
-| `0xa2` | LOG2 | Append log record with two topics | - | 1125 |
-| `0xa3` | LOG3 | Append log record with three topics | - | 1500 |
-| `0xa4` | LOG4 | Append log record with four topics | - | 1875 |
-| `0xa5` - `0xaf` | Unused | - |
-| `0xb0` | JUMPTO | Tentative [libevmasm has different numbers](https://github.com/ethereum/solidity/blob/c61610302aa2bfa029715b534719d25fe3949059/libevmasm/Instruction.h#L176)| [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb1` | JUMPIF | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb2` | JUMPSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb4` | JUMPSUBV | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb5` | BEGINSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb6` | BEGINDATA | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb8` | RETURNSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xb9` | PUTLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xba` | GETLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| `0xbb` - `0xe0` | Unused | - |
-| `0xe1` | SLOADBYTES | Only referenced in pyethereum | - | - |
-| `0xe2` | SSTOREBYTES | Only referenced in pyethereum | - | - |
-| `0xe3` | SSIZE | Only referenced in pyethereum | - | - |
-| `0xe4` - `0xef` | Unused | - |
-| `0xf0` | CREATE | Create a new account with associated code | - | 32000 |
-| `0xf1` | CALL | Message-call into an account | - | Complicated |
-| `0xf2` | CALLCODE | Message-call into this account with alternative account's code | - | Complicated |
-| `0xf3` | RETURN | Halt execution returning output data | - | 0 |
-| `0xf4` | DELEGATECALL | Message-call into this account with an alternative account's code, but persisting into this account with an alternative account's code | - | Complicated |
-| `0xf5` | CREATE2 | Create a new account and set creation address to `sha3(sender + sha3(init code)) % 2**160` | - |
-| `0xf6` - `0xf9` | Unused | - | - |
-| `0xfa` | STATICCALL | Similar to CALL, but does not modify state | - | 40 |
-| `0xfb` | Unused | - | - |
-| `0xfc` | TXEXECGAS | Not in yellow paper FIXME | - | - |
-| `0xfd` | REVERT | Stop execution and revert state changes, without consuming all provided gas and providing a reason | - | 0 |
-| `0xfe` | INVALID | Designated invalid instruction | - | 0 |
-| `0xff` | SELFDESTRUCT | Halt execution and register account for later deletion | - | 5000* | 
+| [`0x00`](#stop) | STOP | Halts execution | - | 0 |
+| [`0x01`](#add) | ADD | Addition operation | - | 3 |
+| [`0x02`](#mul) | MUL | Multiplication operation | - | 5 |
+| [`0x03`](#sub) | SUB | Subtraction operation | - | 3 |
+| [`0x04`](#div) | DIV | Integer division operation | - | 5 |
+| [`0x05`](#sdiv) | SDIV | Signed integer division operation (truncated) | - | 5 |
+| [`0x06`](#mod) | MOD | Modulo remainder operation | - | 5 |
+| [`0x07`](#smod) | SMOD | Signed modulo remainder operation | - | 5 |
+| [`0x08`](#addmod) | ADDMOD | Modulo addition operation | - | 8 |
+| [`0x09`](#mulmod) | MULMOD | Modulo multiplication operation | - | 8 |
+| [`0x0a`](#exp) | EXP | Exponential operation | - | 10* |
+| [`0x0b`](#signextend) | SIGNEXTEND | Extend length of two's complement signed integer | - | 5 |
+| [`0x0c`](#unused) - `0x0f` | Unused | Unused | - |
+| [`0x10`](#lt) | LT | Less-than comparison | - | 3 |
+| [`0x11`](#gt) | GT | Greater-than comparison | - | 3 |
+| [`0x12`](#slt) | SLT | Signed less-than comparison | - | 3 |
+| [`0x13`](#sgt) | SGT | Signed greater-than comparison | - | 3 |
+| [`0x14`](#eq) | EQ | Equality comparison | - | 3 |
+| [`0x15`](#iszero) | ISZERO | Simple not operator | - | 3 |
+| [`0x16`](#and) | AND | Bitwise AND operation | - | 3 |
+| [`0x17`](#or) | OR | Bitwise OR operation | - | 3 |
+| [`0x18`](#xor) | XOR | Bitwise XOR operation | - | 3 |
+| [`0x19`](#not) | NOT | Bitwise NOT operation | - | 3 |
+| [`0x1a`](#byte) | BYTE | Retrieve single byte from word | - | 3 |
+| [`0x1b`](#shl) | SHL | Shift Left | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
+| [`0x1c`](#shr) | SHR | Logical Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
+| [`0x1d`](#sar) | SAR | Arithmetic Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
+| [`0x20`](#keccak256) | KECCAK256 | Compute Keccak-256 hash | - | 30* |
+| [`0x21`](#unused) - `0x2f`| Unused | Unused |
+| [`0x30`](#address) | ADDRESS | Get address of currently executing account | - | 2 |
+| [`0x31`](#balance) | BALANCE | Get balance of the given account | - | 700 |
+| [`0x32`](#origin) | ORIGIN | Get execution origination address | - | 2 |
+| [`0x33`](#caller) | CALLER | Get caller address | - | 2 |
+| [`0x34`](#callvalue) | CALLVALUE | Get deposited value by the instruction/transaction responsible for this execution | - | 2 |
+| [`0x35`](#calldataload) | CALLDATALOAD | Get input data of current environment | - | 3 |
+| [`0x36`](#calldatasize) | CALLDATASIZE | Get size of input data in current environment | - | 2* |
+| [`0x37`](#calldatacopy) | CALLDATACOPY | Copy input data in current environment to memory | - | 3 |
+| [`0x38`](#codesize) | CODESIZE | Get size of code running in current environment | - | 2 |
+| [`0x39`](#codecopy) | CODECOPY | Copy code running in current environment to memory | - | 3* |
+| [`0x3a`](#gasprice) | GASPRICE | Get price of gas in current environment | - | 2 |
+| [`0x3b`](#extcodesize) | EXTCODESIZE | Get size of an account's code | - | 700 |
+| [`0x3c`](#extcodecopy) | EXTCODECOPY | Copy an account's code to memory | - | 700* |
+| [`0x3d`](#returndatasize) | RETURNDATASIZE | Pushes the size of the return data buffer onto the stack | [EIP 211](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-211.md) | 2 |
+| [`0x3e`](#returndatacopy) | RETURNDATACOPY | Copies data from the return data buffer to memory | [EIP 211](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-211.md) | 3 |
+| [`0x3f`](#extcodehash) | EXTCODEHASH | Returns the keccak256 hash of a contract's code | [EIP 1052](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md) | 700 |
+| [`0x40`](#blockhash) | BLOCKHASH | Get the hash of one of the 256 most recent complete blocks | - | 20 |
+| [`0x41`](#coinbase) | COINBASE | Get the block's beneficiary address | - | 2 |
+| [`0x42`](#timestamp) | TIMESTAMP | Get the block's timestamp | - | 2 |
+| [`0x43`](#number) | NUMBER | Get the block's number | - | 2 |
+| [`0x44`](#difficulty) | DIFFICULTY | Get the block's difficulty | - | 2 |
+| [`0x45`](#gaslimit) | GASLIMIT | Get the block's gas limit | - | 2 |
+| [`0x46`](#chainid) | CHAINID | Returns the current chain’s EIP-155 unique identifier | [EIP 1344](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md) | 2 |
+| [`0x47`](#unused) - `0x4f` | Unused | - |
+| [`0x48`](#basefee) | BASEFEE | Returns the value of the base fee of the current block it is executing in. | [EIP 3198](https://eips.ethereum.org/EIPS/eip-3198) | 2 |
+| [`0x50`](#pop) | POP | Remove word from stack | - | 2 |
+| [`0x51`](#mload) | MLOAD | Load word from memory | - | 3* |
+| [`0x52`](#mstore) | MSTORE | Save word to memory | - | 3* |
+| [`0x53`](#mstore8) | MSTORE8 | Save byte to memory | - | 3 |
+| [`0x54`](#sload) | SLOAD | Load word from storage | - | 800 |
+| [`0x55`](#sstore) | SSTORE | Save word to storage | - | 20000** |
+| [`0x56`](#jump) | JUMP | Alter the program counter | - | 8 |
+| [`0x57`](#jumpi) | JUMPI | Conditionally alter the program counter | - | 10 |
+| [`0x58`](#getpc) | GETPC | Get the value of the program counter prior to the increment | - | 2 |
+| [`0x59`](#msize) | MSIZE | Get the size of active memory in bytes | - | 2 |
+| [`0x5a`](#gas) | GAS | Get the amount of available gas, including the corresponding reduction for the cost of this instruction | - | 2 |
+| [`0x5b`](#jumpdest) | JUMPDEST | Mark a valid destination for jumps | - | 1 |
+| [`0x5c`](#unused) - `0x5f` | Unused | - |
+| [`0x60`](#push1) | PUSH1 | Place 1 byte item on stack | - | 3 |
+| [`0x61`](#push2) | PUSH2 | Place 2-byte item on stack | - | 3 |
+| [`0x62`](#push3) | PUSH3 | Place 3-byte item on stack | - | 3 |
+| [`0x63`](#push4) | PUSH4 | Place 4-byte item on stack | - | 3 |
+| [`0x64`](#push5) | PUSH5 | Place 5-byte item on stack | - | 3 |
+| [`0x65`](#push6) | PUSH6 | Place 6-byte item on stack | - | 3 |
+| [`0x66`](#push7) | PUSH7 | Place 7-byte item on stack | - | 3 |
+| [`0x67`](#push8) | PUSH8 | Place 8-byte item on stack | - | 3 |
+| [`0x68`](#push9) | PUSH9 | Place 9-byte item on stack | - | 3 |
+| [`0x69`](#push10) | PUSH10 | Place 10-byte item on stack | - | 3 |
+| [`0x6a`](#push11) | PUSH11 | Place 11-byte item on stack | - | 3 |
+| [`0x6b`](#push12) | PUSH12 | Place 12-byte item on stack | - | 3 |
+| [`0x6c`](#push13) | PUSH13 | Place 13-byte item on stack | - | 3 |
+| [`0x6d`](#push14) | PUSH14 | Place 14-byte item on stack | - | 3 |
+| [`0x6e`](#push15) | PUSH15 | Place 15-byte item on stack | - | 3 |
+| [`0x6f`](#push16) | PUSH16 | Place 16-byte item on stack | - | 3 |
+| [`0x70`](#push17) | PUSH17 | Place 17-byte item on stack | - | 3 |
+| [`0x71`](#push18) | PUSH18 | Place 18-byte item on stack | - | 3 |
+| [`0x72`](#push19) | PUSH19 | Place 19-byte item on stack | - | 3 |
+| [`0x73`](#push20) | PUSH20 | Place 20-byte item on stack | - | 3 |
+| [`0x74`](#push21) | PUSH21 | Place 21-byte item on stack | - | 3 |
+| [`0x75`](#push22) | PUSH22 | Place 22-byte item on stack | - | 3 |
+| [`0x76`](#push23) | PUSH23 | Place 23-byte item on stack | - | 3 |
+| [`0x77`](#push24) | PUSH24 | Place 24-byte item on stack | - | 3 |
+| [`0x78`](#push25) | PUSH25 | Place 25-byte item on stack | - | 3 |
+| [`0x79`](#push26) | PUSH26 | Place 26-byte item on stack | - | 3 |
+| [`0x7a`](#push27) | PUSH27 | Place 27-byte item on stack | - | 3 |
+| [`0x7b`](#push28) | PUSH28 | Place 28-byte item on stack | - | 3 |
+| [`0x7c`](#push29) | PUSH29 | Place 29-byte item on stack | - | 3 |
+| [`0x7d`](#push30) | PUSH30 | Place 30-byte item on stack | - | 3 |
+| [`0x7e`](#push31) | PUSH31 | Place 31-byte item on stack | - | 3 |
+| [`0x7f`](#push32) | PUSH32 | Place 32-byte (full word) item on stack | - |  3 |
+| [`0x80`](#dup1) | DUP1 | Duplicate 1st stack item | - |  3 |
+| [`0x81`](#dup2) | DUP2 | Duplicate 2nd stack item | - | 3 |
+| [`0x82`](#dup3) | DUP3 | Duplicate 3rd stack item | - | 3 |
+| [`0x83`](#dup4) | DUP4 | Duplicate 4th stack item | - | 3 |
+| [`0x84`](#dup5) | DUP5 | Duplicate 5th stack item | - | 3 |
+| [`0x85`](#dup6) | DUP6 | Duplicate 6th stack item | - | 3 |
+| [`0x86`](#dup7) | DUP7 | Duplicate 7th stack item | - | 3 |
+| [`0x87`](#dup8) | DUP8 | Duplicate 8th stack item | - | 3 |
+| [`0x88`](#dup9) | DUP9 | Duplicate 9th stack item | - | 3 |
+| [`0x89`](#dup10) | DUP10 | Duplicate 10th stack item | - | 3 |
+| [`0x8a`](#dup11) | DUP11 | Duplicate 11th stack item | - | 3 |
+| [`0x8b`](#dup12) | DUP12 | Duplicate 12th stack item | - | 3 |
+| [`0x8c`](#dup13) | DUP13 | Duplicate 13th stack item | - | 3 |
+| [`0x8d`](#dup14) | DUP14 | Duplicate 14th stack item | - | 3 |
+| [`0x8e`](#dup15) | DUP15 | Duplicate 15th stack item | - | 3 |
+| [`0x8f`](#dup16) | DUP16 | Duplicate 16th stack item | - | 3 |
+| [`0x90`](#swap1) | SWAP1 | Exchange 1st and 2nd stack items | - | 3 |
+| [`0x91`](#swap2) | SWAP2 | Exchange 1st and 3rd stack items | - | 3 |
+| [`0x92`](#swap3) | SWAP3 | Exchange 1st and 4th stack items | - | 3 |
+| [`0x93`](#swap4) | SWAP4 | Exchange 1st and 5th stack items | - | 3 |
+| [`0x94`](#swap5) | SWAP5 | Exchange 1st and 6th stack items | - | 3 |
+| [`0x95`](#swap6) | SWAP6 | Exchange 1st and 7th stack items | - | 3 |
+| [`0x96`](#swap7) | SWAP7 | Exchange 1st and 8th stack items | - | 3 |
+| [`0x97`](#swap8) | SWAP8 | Exchange 1st and 9th stack items | - | 3 |
+| [`0x98`](#swap9) | SWAP9 | Exchange 1st and 10th stack items | - | 3 |
+| [`0x99`](#swap10) | SWAP10 | Exchange 1st and 11th stack items | - | 3 |
+| [`0x9a`](#swap11) | SWAP11 | Exchange 1st and 12th stack items | - | 3 |
+| [`0x9b`](#swap12) | SWAP12 | Exchange 1st and 13th stack items | - | 3 |
+| [`0x9c`](#swap13) | SWAP13 | Exchange 1st and 14th stack items | - | 3 |
+| [`0x9d`](#swap14) | SWAP14 | Exchange 1st and 15th stack items | - | 3 |
+| [`0x9e`](#swap15) | SWAP15 | Exchange 1st and 16th stack items | - | 3 |
+| [`0x9f`](#swap16) | SWAP16 | Exchange 1st and 17th stack items | - | 3 |
+| [`0xa0`](#log0) | LOG0 | Append log record with no topics | - | 375 |
+| [`0xa1`](#log1) | LOG1 | Append log record with one topic | - | 750 |
+| [`0xa2`](#log2) | LOG2 | Append log record with two topics | - | 1125 |
+| [`0xa3`](#log3) | LOG3 | Append log record with three topics | - | 1500 |
+| [`0xa4`](#log4) | LOG4 | Append log record with four topics | - | 1875 |
+| [`0xa5`](#unused) - `0xaf` | Unused | - |
+| [`0xb0`](#jumpto) | JUMPTO | Tentative [libevmasm has different numbers](https://github.com/ethereum/solidity/blob/c61610302aa2bfa029715b534719d25fe3949059/libevmasm/Instruction.h#L176)| [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb1`](#jumpif) | JUMPIF | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb2`](#jumpsub) | JUMPSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb4`](#jumpsubv) | JUMPSUBV | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb5`](#beginsub) | BEGINSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb6`](#begindata) | BEGINDATA | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb8`](#returnsub) | RETURNSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xb9`](#putlocal) | PUTLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xba`](#getlocal) | GETLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
+| [`0xbb`](#unused) - `0xe0` | Unused | - |
+| [`0xe1`](#sloadbytes) | SLOADBYTES | Only referenced in pyethereum | - | - |
+| [`0xe2`](#sstorebytes) | SSTOREBYTES | Only referenced in pyethereum | - | - |
+| [`0xe3`](#ssize) | SSIZE | Only referenced in pyethereum | - | - |
+| [`0xe4`](#unused) - `0xef` | Unused | - |
+| [`0xf0`](#create) | CREATE | Create a new account with associated code | - | 32000 |
+| [`0xf1`](#call) | CALL | Message-call into an account | - | Complicated |
+| [`0xf2`](#callcode) | CALLCODE | Message-call into this account with alternative account's code | - | Complicated |
+| [`0xf3`](#return) | RETURN | Halt execution returning output data | - | 0 |
+| [`0xf4`](#delegatecall) | DELEGATECALL | Message-call into this account with an alternative account's code, but persisting into this account with an alternative account's code | - | Complicated |
+| [`0xf5`](#create2) | CREATE2 | Create a new account and set creation address to `sha3(sender + sha3(init code)) % 2**160` | - |
+| [`0xf6`](#unused) - `0xf9` | Unused | - | - |
+| [`0xfa`](#staticcall) | STATICCALL | Similar to CALL, but does not modify state | - | 40 |
+| [`0xfb`](#unused) | Unused | - | - |
+| [`0xfc`](#txexecgas) | TXEXECGAS | Not in yellow paper FIXME | - | - |
+| [`0xfd`](#revert) | REVERT | Stop execution and revert state changes, without consuming all provided gas and providing a reason | - | 0 |
+| [`0xfe`](#invalid) | INVALID | Designated invalid instruction | - | 0 |
+| [`0xff`](#selfdestruct) | SELFDESTRUCT | Halt execution and register account for later deletion | - | 5000* | 
 
 ## Instruction Details
 
+-----
+### STOP
+**0x00**
+
+() => ()
+
+halts execution
+
+-----
 ### ADD
+**0x01**
 
 Takes two words from stack, adds them, then pushes the result onto the stack.
 
-Pseudocode: `push(s[0]+s[1])`
+(a, b) => (c)
 
-### PUSHX
+c = a + b
 
-The following X bytes are read from PC, placed into a word, then this word is pushed onto the stack.
+-----
+### MUL
+**0x02**
 
-### SHR
+(a, b) => (c)
 
-Pops 2 elements from the stack and pushes the second element onto the stack shifted right by the shift amount (first element). 
+c = a * b
 
+-----
+### SUB
+**0x03**
+
+(a, b) => (c)
+
+c = a - b
+
+-----
+### DIV
+**0x04**
+
+(a, b) => (c)
+
+c = a / b
+
+-----
+### SDIV
+**0x05**
+
+(a: int256, b: int256) => (c: int256)
+
+c = a / b
+
+-----
+### MOD
+**0x06**
+
+(a, b) => (c)
+
+c = a % b
+
+-----
+### SMOD
+**0x07**
+
+(a: int256, b: int256) => (c: int256)
+
+c = a % b
+
+-----
+### ADDMOD
+**0x08**
+
+(a, b, m) => (c)
+
+c = (a + b) % m
+
+-----
+### MULMOD
+**0x09**
+
+(a, b, m) => (c)
+
+c = (a * b) % m
+
+-----
+### EXT
+**0x0a**
+
+(a, b, m) => (c)
+
+c = (a * b) % m
+
+-----
+### SIGNEXTEND
+**0x0b**
+
+(b, x) => (y)
+
+y = SIGNEXTEND(x, b)
+
+sign extends x from (b + 1) * 8 bits to 256 bits.
+
+-----
+### LT
+**0x10**
+
+(a, b) => (c)
+
+c = a < b
+
+all values interpreted as uint256
+
+-----
+### GT
+**0x11**
+
+(a, b) => (c)
+
+c = a > b
+
+all values interpreted as uint256
+
+-----
+### SLT
+**0x12**
+
+(a, b) => (c)
+
+c = a < b
+
+all values interpreted as int256
+
+-----
+### SGT
+**0x13**
+
+(a, b) => (c)
+
+c = a > b
+
+all values interpreted as int256
+
+-----
+### EQ
+**0x14**
+
+Pops 2 elements off the stack and pushes the value 1 to the stack in case they're equal, otherwise the value 0.
+
+(a, b) => (c)
+
+c = a == b
+
+-----
+### ISZERO
+**0x15**
+
+(a) => (c)
+
+c = a == 0
+
+-----
+### AND
+**0x16**
+
+(a, b) => (c)
+
+c = a & b
+
+-----
+### OR
+**0x17**
+
+(a, b) => (c)
+
+c = a | b
+
+-----
+### XOR
+**0x18**
+
+(a, b) => (c)
+
+c = a ^ b
+
+-----
+### NOT
+**0x19**
+
+(a) => (c)
+
+c = ~a
+
+-----
+### BYTE
+**0x1a**
+
+(i, x) => (y)
+
+y = (x >> (248 - i * 8) & 0xff
+
+-----
 ### SHL
+**0x1b**
 
 Pops 2 elements from the stack and pushes the second element onto the stack shifted left by the shift amount (first element).  
 
+(shift, value) => (res)
+
+res = value << shift
+
+-----
+### SHR
+**0x1c**
+
+Pops 2 elements from the stack and pushes the second element onto the stack shifted right by the shift amount (first element). 
+
+(shift, value) => (res)
+
+res = value >> shift
+
+-----
+### SAR
+**0x1d**
+
+(shift, value) => (res)
+
+res = value >> shift
+
+value: int256
+
+-----
+### SHA3
+**0x20**
+
+(offset, len) => (hash)
+
+hash = keccak256(memory[offset:offset+len])
+
+-----
+### ADDRESS
+**0x30**
+
+() => (address(this))
+
+-----
+### BALANCE
+**0x31**
+
+() => (address(this).balance)
+
+-----
+### ORIGIN
+**0x32**
+
+() => (tx.origin)
+
+-----
+### CALLER
+**0x33**
+
+() => (msg.sender)
+
+-----
+### CALLVALUE
+**0x34**
+
+() => (msg.value)
+
+-----
+### CALLDATALOAD
+**0x35**
+
+(index) => (msg.data[index:index+32])
+
+-----
+### CALLDATASIZE
+**0x36**
+
+() => (msg.data.size)
+
+-----
+### CALLDATACOPY
+**0x37**
+
+(memOffset, offset, length) => ()
+
+memory[memOffset:memOffset+len] = msg.data[offset:offset+len]
+
+-----
+### CODESIZE
+**0x38**
+
+() => (address(this).code.size)
+
+-----
+### CODECOPY
+**0x39**
+
+(memOffset, codeOffset, len) => ()
+
+memory[memOffset:memOffset+len] = address(this).code[codeOffset:codeOffset+len]
+
+-----
+### GASPRICE
+**0x3a**
+
+() => (tx.gasprice)
+
+-----
+### EXTCODESIZE
+**0x3b**
+
+(addr) => (address(addr).code.size)
+
+-----
+### EXTCODECOPY
+**0x3c**
+
+(addr, memOffset, offset, length) => ()
+
+memory[memOffset:memOffset+len] = address(addr).code[codeOffset:codeOffset+len]
+
+-----
+### RETURNDATASIZE
+**0x3d**
+
+() => (size)
+
+size = RETURNDATASIZE()
+
+The number of bytes that were returned from the last ext call
+
+-----
+### RETURNDATACOPY
+**0x3e**
+
+(memOffset, offset, length) => ()
+
+memory[memOffset:memOffset+len] = RETURNDATA[codeOffset:codeOffset+len]
+
+RETURNDATA is the data returned from the last external call
+
+-----
+### EXTCODEHASH
+**0x3f**
+
+(addr) => (hash)
+
+hash = address(addr).exists ? keccak256(address(addr).code) : 0
+
+-----
+### BLOCKHASH
+**0x40**
+
+(number) => (hash)
+
+hash = block.blockHash(number)
+
+-----
+### COINBASE
+**0x41**
+
+() => (block.coinbase)
+
+-----
+### TIMESTAMP
+**0x42**
+
+() => (block.timestamp)
+
+-----
+### NUMBER
+**0x43**
+
+() => (block.number)
+
+-----
+### DIFFICULTY
+**0x44**
+
+() => (block.difficulty)
+
+-----
+### GASLIMIT
+**0x45**
+
+() => (block.gaslimit)
+
+-----
+### CHAINID
+**0x46**
+
+() => (chainid)
+
+where chainid = 1 for mainnet & some other value for other networks
+
+-----
+### SELFBALANCE
+**0x47**
+
+() => (address(this).balance)
+
+-----
+### BASEFEE
+**0x48**
+
+() => (block.basefee)
+
+current block's base fee (related to EIP1559)
+
+-----
+### POP
+**0x50**
+
+(a) => ()
+
+discards the top stack item
+
+-----
+### MLOAD
+**0x51**
+
+(offset) => (value)
+
+value = memory[offset:offset+32]
+
+-----
 ### MSTORE
+**0x52**
 
 Saves a word to the EVM memory. Pops 2 elements from stack - the first element being the word memory address where the saved value (second element popped from stack) will be stored. 
 
-### EQ
-Pops 2 elements off the stack and pushes the value 1 to the stack in case they're equal, otherwise the value 0.
+(offset, value) => ()
 
-### JUMPI (Jump If)
-Conditional - Pops 2 elements from the stack, the first element being the jump location and the second being the value 0 (false) or 1 (true). If the value’s 1 the PC will be altered and the jump executed. Otherwise, the value will be 0 and the PC will remain the same and execution unaltered.
+memory[offset:offset+32] = value
 
+-----
+### MSTORE8
+**0x53**
+
+(offset, value) => ()
+
+memory[offset:offset+32] = value & 0xff
+
+-----
+### SLOAD
+**0x54**
+
+Pops 1 element off the stack, that being the key which is the storage slot and returns the read value stored there. 
+
+(key) => (value)
+
+value = storage[key]
+
+-----
 ### SSTORE
+**0x55**
+
 Pops 2 elements off the stack, the first element being the key and the second being the value which is then stored at the storage slot represented from the first element (key). 
 
-### SLOAD
-Pops 1 element off the stack, that being the key which is the storage slot and returns the read value stored there. 
+(key, value) => ()
+
+storage[key] = value
+
+-----
+### JUMP
+**0x56**
+
+(dest) => ()
+
+pc = dest
+
+-----
+### JUMPI
+**0x57**
+
+Conditional - Pops 2 elements from the stack, the first element being the jump location and the second being the value 0 (false) or 1 (true). If the value’s 1 the PC will be altered and the jump executed. Otherwise, the value will be 0 and the PC will remain the same and execution unaltered.
+
+(dest, cond) => ()
+
+pc = cond ? dest : pc + 1
+
+-----
+### PC
+**0x58**
+
+() => (pc)
+
+-----
+### MSIZE
+**0x59**
+
+() => (memory.size)
+
+-----
+### GAS
+**0x5a**
+
+() => (gasRemaining)
+
+not including the gas required for this opcode
+
+-----
+### JUMPDEST
+**0x5b**
+
+() => ()
+
+noop, marks a valid jump destination
+
+-----
+### PUSH1
+**0x60**
+
+The following byte is read from PC, placed into a word, then this word is pushed onto the stack.
+
+() => (address(this).code[pc+1:pc+2])
+
+-----
+### PUSH2
+**0x61**
+
+() => (address(this).code[pc+2:pc+3])
+
+-----
+### PUSH3
+**0x62**
+
+() => (address(this).code[pc+3:pc+4])
+
+-----
+### PUSH4
+**0x63**
+
+() => (address(this).code[pc+4:pc+5])
+
+-----
+### PUSH5
+**0x64**
+
+() => (address(this).code[pc+5:pc+6])
+
+-----
+### PUSH6
+**0x65**
+
+() => (address(this).code[pc+6:pc+7])
+
+-----
+### PUSH7
+**0x66**
+
+() => (address(this).code[pc+7:pc+8])
+
+-----
+### PUSH8
+**0x67**
+
+() => (address(this).code[pc+8:pc+9])
+
+-----
+### PUSH9
+**0x68**
+
+() => (address(this).code[pc+9:pc+10])
+
+-----
+### PUSH10
+**0x69**
+
+() => (address(this).code[pc+10:pc+11])
+
+-----
+### PUSH11
+**0x6a**
+
+() => (address(this).code[pc+11:pc+12])
+
+-----
+### PUSH12
+**0x6b**
+
+() => (address(this).code[pc+12:pc+13])
+
+-----
+### PUSH13
+**0x6c**
+
+() => (address(this).code[pc+13:pc+14])
+
+-----
+### PUSH14
+**0x6d**
+
+() => (address(this).code[pc+14:pc+15])
+
+-----
+### PUSH15
+**0x6e**
+
+() => (address(this).code[pc+15:pc+16])
+
+-----
+### PUSH16
+**0x6f**
+
+() => (address(this).code[pc+16:pc+17])
+
+-----
+### PUSH17
+**0x70**
+
+() => (address(this).code[pc+17:pc+18])
+
+-----
+### PUSH18
+**0x71**
+
+() => (address(this).code[pc+18:pc+19])
+
+-----
+### PUSH19
+**0x72**
+
+() => (address(this).code[pc+19:pc+20])
+
+-----
+### PUSH20
+**0x73**
+
+() => (address(this).code[pc+20:pc+21])
+
+-----
+### PUSH21
+**0x74**
+
+() => (address(this).code[pc+21:pc+22])
+
+-----
+### PUSH22
+**0x75**
+
+() => (address(this).code[pc+22:pc+23])
+
+-----
+### PUSH23
+**0x76**
+
+() => (address(this).code[pc+23:pc+24])
+
+-----
+### PUSH24
+**0x77**
+
+() => (address(this).code[pc+24:pc+25])
+
+-----
+### PUSH25
+**0x78**
+
+() => (address(this).code[pc+25:pc+26])
+
+-----
+### PUSH26
+**0x79**
+
+() => (address(this).code[pc+26:pc+27])
+
+-----
+### PUSH27
+**0x7a**
+
+() => (address(this).code[pc+27:pc+28])
+
+-----
+### PUSH28
+**0x7b**
+
+() => (address(this).code[pc+28:pc+29])
+
+-----
+### PUSH29
+**0x7c**
+
+() => (address(this).code[pc+29:pc+30])
+
+-----
+### PUSH30
+**0x7d**
+
+() => (address(this).code[pc+30:pc+31])
+
+-----
+### PUSH31
+**0x7e**
+
+() => (address(this).code[pc+31:pc+32])
+
+-----
+### PUSH32
+**0x7f**
+
+() => (address(this).code[pc+32:pc+33])
+
+-----
+### DUP1
+**0x80**
+
+(1) => (1, 1)
+
+-----
+### DUP2
+**0x81**
+
+(1, 2) => (2, 1, 2)
+
+-----
+### DUP3
+**0x82**
+
+(1, 2, 3) => (3, 1, 2, 3)
+
+-----
+### DUP4
+**0x83**
+
+(1, ..., 4) => (4, 1, ..., 4)
+
+-----
+### DUP5
+**0x84**
+
+(1, ..., 5) => (5, 1, ..., 5)
+
+-----
+### DUP6
+**0x85**
+
+(1, ..., 6) => (6, 1, ..., 6)
+
+-----
+### DUP7
+**0x86**
+
+(1, ..., 7) => (7, 1, ..., 7)
+
+-----
+### DUP8
+**0x87**
+
+(1, ..., 8) => (8, 1, ..., 8)
+
+-----
+### DUP9
+**0x88**
+
+(1, ..., 9) => (9, 1, ..., 9)
+
+-----
+### DUP10
+**0x89**
+
+(1, ..., 10) => (10, 1, ..., 10)
+
+-----
+### DUP11
+**0x8a**
+
+(1, ..., 11) => (11, 1, ..., 11)
+
+-----
+### DUP12
+**0x8b**
+
+(1, ..., 12) => (12, 1, ..., 12)
+
+-----
+### DUP13
+**0x8c**
+
+(1, ..., 13) => (13, 1, ..., 13)
+
+-----
+### DUP14
+**0x8d**
+
+(1, ..., 14) => (14, 1, ..., 14)
+
+-----
+### DUP15
+**0x8e**
+
+(1, ..., 15) => (15, 1, ..., 15)
+
+-----
+### DUP16
+**0x8f**
+
+(1, ..., 16) => (16, 1, ..., 16)
+
+-----
+### SWAP1
+**0x90**
+
+(1, 2) => (2, 1)
+
+-----
+### SWAP2
+**0x91**
+
+(1, 2, 3) => (3, 2, 1)
+
+-----
+### SWAP3
+**0x92**
+
+(1, ..., 4) => (4, ..., 1)
+
+-----
+### SWAP4
+**0x93**
+
+(1, ..., 5) => (5, ..., 1)
+
+-----
+### SWAP5
+**0x94**
+
+(1, ..., 6) => (6, ..., 1)
+
+-----
+### SWAP6
+**0x95**
+
+(1, ..., 7) => (7, ..., 1)
+
+-----
+### SWAP7
+**0x96**
+
+(1, ..., 8) => (8, ..., 1)
+
+-----
+### SWAP8
+**0x97**
+
+(1, ..., 9) => (9, ..., 1)
+
+-----
+### SWAP9
+**0x98**
+
+(1, ..., 10) => (10, ..., 1)
+
+-----
+### SWAP10
+**0x99**
+
+(1, ..., 11) => (11, ..., 1)
+
+-----
+### SWAP11
+**0x9a**
+
+(1, ..., 12) => (12, ..., 1)
+
+-----
+### SWAP12
+**0x9b**
+
+(1, ..., 13) => (13, ..., 1)
+
+-----
+### SWAP13
+**0x9c**
+
+(1, ..., 14) => (14, ..., 1)
+
+-----
+### SWAP14
+**0x9d**
+
+(1, ..., 15) => (15, ..., 1)
+
+-----
+### SWAP15
+**0x9e**
+
+(1, ..., 16) => (16, ..., 1)
+
+-----
+### SWAP16
+**0x9f**
+
+(1, ..., 17) => (17, ..., 1)
+
+-----
+### LOG0
+**0xa0**
+
+(offset, length) => ()
+
+emit(memory[offset:offset+length])
+
+-----
+### LOG1
+**0xa1**
+
+(offset, length, topic0) => ()
+
+emit(memory[offset:offset+length], topic0)
+
+-----
+### LOG2
+**0xa2**
+
+(offset, length, topic0, topic1) => ()
+
+emit(memory[offset:offset+length], topic0, topic1)
+
+-----
+### LOG3
+**0xa3**
+
+(offset, length, topic0, topic1, topic2) => ()
+
+emit(memory[offset:offset+length], topic0, topic1, topic2)
+
+-----
+### LOG4
+**0xa4**
+
+(offset, length, topic0, topic1, topic2, topic3) => ()
+
+emit(memory[offset:offset+length], topic0, topic1, topic2, topic3)
+
+-----
+### CREATE
+**0xf0**
+
+(value, offset, length) => (addr)
+
+addr = keccak256(rlp([address(this), this.nonce]))[12:]
+addr.code = exec(memory[offset:offset+length])
+addr.balance += value
+this.balance -= value
+this.nonce += 1
+
+-----
+### CALL
+**0xf1**
+
+(gas, addr, value, argsOffset, argsLength, retOffset, retLength) => (success)
+
+memory[retOffset:retOffset+retLength] = address(addr).callcode.gas(gas).value(value)(memory[argsOffset:argsOffset+argsLength])
+success = true (unless the prev call reverted)
+
+-----
+### CALLCODE
+**0xf2**
+
+(gas, addr, value, argsOffset, argsLength, retOffset, retLength) => (success)
+
+memory[retOffset:retOffset+retLength] = address(addr).callcode.gas(gas).value(value)(memory[argsOffset:argsOffset+argsLength])
+success = true (unless the prev call reverted)
+
+TODO: what's the difference between this & CALL?
+
+-----
+### RETURN
+**0xf3**
+
+(offset, length) => ()
+
+return memory[offset:offset+length]
+
+-----
+### DELEGATECALL
+**0xf4**
+
+(gas, addr, argsOffset, argsLength, retOffset, retLength) => (success)
+
+memory[retOffset:retOffset+retLength] = address(addr).delegatecall.gas(gas)(memory[argsOffset:argsOffset+argsLength])
+success = true (unless the prev call reverted)
+
+-----
+### CREATE2
+**0xf5**
+
+(value, offset, length, salt) => (addr)
+
+initCode = memory[offset:offset+length]
+addr = keccak256(0xff ++ address(this) ++ salt ++ keccak256(initCode))[12:]
+address(addr).code = exec(initCode)
+
+
+-----
+### STATICCALL
+**0xfa**
+
+(gas, addr, argsOffset, argsLength, retOffset, retLength) => (success)
+
+memory[retOffset:retOffset+retLength] = address(addr).delegatecall.gas(gas)(memory[argsOffset:argsOffset+argsLength])
+success = true (unless the prev call reverted)
+
+TODO: what's the difference between this & DELEGATECALL?
+
+-----
+### REVERT
+**0xfd**
+
+(offset, length) => ()
+
+revert(memory[offset:offset+length])
+
+-----
+### SELFDESTRUCT
+**0xff**
+
+(addr) => ()
+
+address(addr).send(address(this).balance)
+this.code = 0

--- a/learn_evm/evm_opcodes.md
+++ b/learn_evm/evm_opcodes.md
@@ -26,7 +26,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0x09`](#mulmod) | MULMOD | Modulo multiplication operation | - | 8 |
 | [`0x0a`](#exp) | EXP | Exponential operation | - | 10* |
 | [`0x0b`](#signextend) | SIGNEXTEND | Extend length of two's complement signed integer | - | 5 |
-| [`0x0c`](#unused) - `0x0f` | Unused | Unused | - |
+| `0x0c` - `0x0f` | Unused | Unused | - |
 | [`0x10`](#lt) | LT | Less-than comparison | - | 3 |
 | [`0x11`](#gt) | GT | Greater-than comparison | - | 3 |
 | [`0x12`](#slt) | SLT | Signed less-than comparison | - | 3 |
@@ -42,7 +42,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0x1c`](#shr) | SHR | Logical Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
 | [`0x1d`](#sar) | SAR | Arithmetic Shift Right | [EIP145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md) | 3 |
 | [`0x20`](#keccak256) | KECCAK256 | Compute Keccak-256 hash | - | 30* |
-| [`0x21`](#unused) - `0x2f`| Unused | Unused |
+| `0x21` - `0x2f`| Unused | Unused |
 | [`0x30`](#address) | ADDRESS | Get address of currently executing account | - | 2 |
 | [`0x31`](#balance) | BALANCE | Get balance of the given account | - | 700 |
 | [`0x32`](#origin) | ORIGIN | Get execution origination address | - | 2 |
@@ -66,7 +66,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0x44`](#difficulty) | DIFFICULTY | Get the block's difficulty | - | 2 |
 | [`0x45`](#gaslimit) | GASLIMIT | Get the block's gas limit | - | 2 |
 | [`0x46`](#chainid) | CHAINID | Returns the current chain’s EIP-155 unique identifier | [EIP 1344](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md) | 2 |
-| [`0x47`](#unused) - `0x4f` | Unused | - |
+| `0x47` - `0x4f` | Unused | - |
 | [`0x48`](#basefee) | BASEFEE | Returns the value of the base fee of the current block it is executing in. | [EIP 3198](https://eips.ethereum.org/EIPS/eip-3198) | 2 |
 | [`0x50`](#pop) | POP | Remove word from stack | - | 2 |
 | [`0x51`](#mload) | MLOAD | Load word from memory | - | 3* |
@@ -80,7 +80,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0x59`](#msize) | MSIZE | Get the size of active memory in bytes | - | 2 |
 | [`0x5a`](#gas) | GAS | Get the amount of available gas, including the corresponding reduction for the cost of this instruction | - | 2 |
 | [`0x5b`](#jumpdest) | JUMPDEST | Mark a valid destination for jumps | - | 1 |
-| [`0x5c`](#unused) - `0x5f` | Unused | - |
+| `0x5c` - `0x5f` | Unused | - |
 | [`0x60`](#push1) | PUSH1 | Place 1 byte item on stack | - | 3 |
 | [`0x61`](#push2) | PUSH2 | Place 2-byte item on stack | - | 3 |
 | [`0x62`](#push3) | PUSH3 | Place 3-byte item on stack | - | 3 |
@@ -150,7 +150,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0xa2`](#log2) | LOG2 | Append log record with two topics | - | 1125 |
 | [`0xa3`](#log3) | LOG3 | Append log record with three topics | - | 1500 |
 | [`0xa4`](#log4) | LOG4 | Append log record with four topics | - | 1875 |
-| [`0xa5`](#unused) - `0xaf` | Unused | - |
+| `0xa5` - `0xaf` | Unused | - |
 | [`0xb0`](#jumpto) | JUMPTO | Tentative [libevmasm has different numbers](https://github.com/ethereum/solidity/blob/c61610302aa2bfa029715b534719d25fe3949059/libevmasm/Instruction.h#L176)| [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
 | [`0xb1`](#jumpif) | JUMPIF | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
 | [`0xb2`](#jumpsub) | JUMPSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
@@ -160,20 +160,20 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | [`0xb8`](#returnsub) | RETURNSUB | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
 | [`0xb9`](#putlocal) | PUTLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
 | [`0xba`](#getlocal) | GETLOCAL | Tentative | [EIP 615](https://github.com/ethereum/EIPs/blob/606405b5ab7aa28d8191958504e8aad4649666c9/EIPS/eip-615.md) |
-| [`0xbb`](#unused) - `0xe0` | Unused | - |
+| `0xbb` - `0xe0` | Unused | - |
 | [`0xe1`](#sloadbytes) | SLOADBYTES | Only referenced in pyethereum | - | - |
 | [`0xe2`](#sstorebytes) | SSTOREBYTES | Only referenced in pyethereum | - | - |
 | [`0xe3`](#ssize) | SSIZE | Only referenced in pyethereum | - | - |
-| [`0xe4`](#unused) - `0xef` | Unused | - |
+| `0xe4` - `0xef` | Unused | - |
 | [`0xf0`](#create) | CREATE | Create a new account with associated code | - | 32000 |
 | [`0xf1`](#call) | CALL | Message-call into an account | - | Complicated |
 | [`0xf2`](#callcode) | CALLCODE | Message-call into this account with alternative account's code | - | Complicated |
 | [`0xf3`](#return) | RETURN | Halt execution returning output data | - | 0 |
 | [`0xf4`](#delegatecall) | DELEGATECALL | Message-call into this account with an alternative account's code, but persisting into this account with an alternative account's code | - | Complicated |
 | [`0xf5`](#create2) | CREATE2 | Create a new account and set creation address to `sha3(sender + sha3(init code)) % 2**160` | - |
-| [`0xf6`](#unused) - `0xf9` | Unused | - | - |
+| `0xf6` - `0xf9` | Unused | - | - |
 | [`0xfa`](#staticcall) | STATICCALL | Similar to CALL, but does not modify state | - | 40 |
-| [`0xfb`](#unused) | Unused | - | - |
+| `0xfb` | Unused | - | - |
 | [`0xfc`](#txexecgas) | TXEXECGAS | Not in yellow paper FIXME | - | - |
 | [`0xfd`](#revert) | REVERT | Stop execution and revert state changes, without consuming all provided gas and providing a reason | - | 0 |
 | [`0xfe`](#invalid) | INVALID | Designated invalid instruction | - | 0 |

--- a/learn_evm/tracing.md
+++ b/learn_evm/tracing.md
@@ -1,0 +1,113 @@
+
+# Tracing Utils
+
+## Transaction Tracing
+
+One great way to learn more about how the EVM works internally is to trace the execution of a transaction opcode by opcode. This technique can also help you assess the correctness of assembly code and catch problems related to the compiler or it's optimization steps.
+
+The following Javascript snippet uses an `ethers` provider to connect to an ethereum node with the `debug` JSON RPC endpoints activated. Although this requires an archive node on mainnet, it can also be run quickly & easily against a local development testnet using hardhat node, ganache, or some other ethprovider that targets developers.
+
+Transaction traces for even simple smart contract interactions are verbose so we recommend you provide a filename to save the trace at for further analysis. Note that the following function depends on the `fs` module built into node.js so it should be copied into a node console rather than a browser console, however the filesystem interactions could be removed for use in the browser.
+
+```
+const ethers = require("ethers");
+const fs = require("fs");
+
+const provider = new ethers.providers.JsonRpcProvider(
+  process.env.ETH_PROVIDER || "http://localhost:8545"
+);
+
+let traceTx = async (txHash, filename) => {
+  await provider.send("debug_traceTransaction", [txHash]).then((res) => {
+    console.log(`Got a response with keys: ${Object.keys(res)}`);
+    const indexedRes = {
+      ...res,
+      structLogs: res.structLogs.map((structLog, index) => ({
+        index,
+        ...structLog,
+      })),
+    };
+    if (filename) {
+      fs.writeFileSync(filename, JSON.stringify(indexedRes, null, 2));
+    } else {
+      log(indexecRes);
+    }
+  });
+};
+```
+
+Note that, by default, transaction traces do not feature a sequential index making it difficult to answer, for example, "Which was the 100th opcode executed?" The above script adds such an index for easier navigation and communication.
+
+The output of the above features a list of opcode executions, a snippet of which might look something like:
+
+```
+{
+  "structLogs": [
+    ...,  
+    {
+      "index": 191,
+      "pc": 3645,
+      "op": "SSTORE",
+      "gas": 10125,
+      "gasCost": 2900,
+      "depth": 1,
+      "stack": [
+        "0xa9059cbb",
+        "0x700",
+        "0x7fb610713c8404e21676c01c271bb662df6eb63c",
+        "0x1d8b64f4775be40000",
+        "0x0",
+        "0x1e01",
+        "0x68e224065325c640131672779181a2f2d1324c4d",
+        "0x7fb610713c8404e21676c01c271bb662df6eb63c",
+        "0x1d8b64f4775be40000",
+        "0x0",
+        "0x14af3e50252dfc40000",
+        "0x14af3e50252dfc40000",
+        "0x7d7d4dc7c32ad4c905ab39fc25c4323c4a85e4b1b17a396514e6b88ee8b814e8"
+      ],
+      "memory": [
+        "00000000000000000000000068e224065325c640131672779181a2f2d1324c4d",
+        "0000000000000000000000000000000000000000000000000000000000000002",
+        "0000000000000000000000000000000000000000000000000000000000000080"
+      ],
+      "storage": {
+        "7d7d4dc7c32ad4c905ab39fc25c4323c4a85e4b1b17a396514e6b88ee8b814e8": "00000000000000000000000000000000000000000000014af3e50252dfc40000"
+      }
+    },
+    ...,  
+  ],
+  "gas": 34718,
+  "failed": false,
+  "returnValue": "0000000000000000000000000000000000000000000000000000000000000001"
+}
+```
+
+An overview of the fields for opcode execution trace:
+- `index`: The index we added, indicates that the above opcode was the 191st one executed. Helpful for staying oriented as you jump around the trace.
+- `pc`: program counter eg this opcode exists at index `3645` of the contract bytecode. You'll notice that `pc` increments by one for many common opcodes, by more than one for PUSH opcodes, and is reset entirely by JUMP/JUMP opcodes.
+- `op`: name of the opcode, because most of the actual data is hex-encoded, using grep or ctrl-f to search through the trace for opcode names is an effective strategy.
+- `gas`: remaining gas *before* the opcode is executed
+- `gasCost`: cost of this operation, for CALL & similar opcodes, this cost takes into account all gas spent by the child execution frame.
+- `depth`: each call creates a new child execution frame & this variable tracks how many sub-frames exist. Generally, CALL opcodes increase the depth and RETURN opcodes decrease it.
+- `stack`: a snapshot of the entire stack *before* the opcode executes
+- `memory`: a snapshot of the entire memory *before* the opcode executes
+- `storage`: an accumulation of all state changes made during the execution of the transaction being traced
+
+One big challenge of navigating such a transaction trace is matching opcode executions to higher-level solidity code. An effective first step is to identify uncommon opcodes which correspond to easily identified logic of the source code. Generally, expensive operations are relatively uncommon so SLOAD and SSTORE are good ones to scan for first and match against places where state variables are being read or written in solidity. Alternatively, CALL and related opcodes are relatively uncommon and can be matched with calls to other contracts in the source code.
+
+If there's a specific part of the source code that you're interested in tracing, matching uncommon opcodes to the source code will give you bounds on where to search. From here, you'll likely start walking through the trace opcode-by-opcode as you review the source code line by line. Leaving a few ephemeral comments in the source code like `# opcode 191` can help you keep track and pick up where you left off if you need to take a break.
+
+Exploring transaction traces is challenging work but the reward is an ultra-high-definition view into how the EVM operates internally and can help you identify problems that might not be apparent from just the source code.
+
+## Storage Tracing
+
+Although you can get an overview of all the changes to the contract state by checking the `storage` field of the last executed opcode in the above trace, the following helper function will extract that for you for quicker and easier analysis. If you're doing a more involved investigation into a contract's state, we recommend you check out the [`slither-read-storage`](https://blog.trailofbits.com/2022/07/28/shedding-smart-contract-storage-with-slither/) command for a more powerful tool.
+
+```
+const traceStorage = async (txHash) => {
+  await provider.send("debug_traceTransaction", [txHash]).then((res) => {
+    log(res.structLogs[res.structLogs.length - 1].storage);
+  });
+};
+```

--- a/learn_evm/yellow-paper.md
+++ b/learn_evm/yellow-paper.md
@@ -1,0 +1,146 @@
+
+# Ethereum Yellow Paper
+
+So, you want to read the yellow paper. Before we dive in, keep in mind that the yellow paper is out of date and some in the community might refer to it as being depreciated. Check out the [BRANCHES.md](https://github.com/ethereum/yellowpaper/blob/master/BRANCHES.md) file of the [`yellowpaper` repository on github](https://github.com/ethereum/yellowpaper) to stay up-to-date on how closely this document tracks the latest version of the Ethereum protocol. At the time of writing, the yellow paper is up to date with the Berlin hardfork which occurred in April 2021.
+
+For a more up-to-date reference, check out the [Ethereum Specification](https://ethereum.github.io/execution-specs/autoapi/ethereum/) which features a detailed description of each opcode *for each hardfork* in addition to reference implementations written in python.
+
+That said, the yellow paper is still a rich resource for ramping up on the fundamentals of the Ethereum protocol. This document aims to provide some guidance and assistance in deciphering Ethereum's flagship specification.
+
+As you review the following, keep in mind that additions and corrections are welcome and are covered by bounties from Trail of Bits. Join us in #ethereum on the [Empire Hacking Slack](https://empireslacking.herokuapp.com) to discuss Ethereum specifications and tool development.
+
+## Mathematical Symbols
+
+One challenging part of the yellow paper, for those of us who are not so well trained in formal mathematics, is comprehending the mathematical symbols. A cheat-sheet of some of these symbols is provided below
+
+ - `∃`: there exists
+ - `∀`: for all
+ - `∧`: and
+ - `∨`: or
+
+And some more Ethereum-specific symbols:
+
+ - `N_{H}`: 1,150,000 aka block number at which the protocol was upgraded from homestead to frontier.
+ - `T`: a transaction eg `T = { n: nonce, p: gasPrice, g: gasLimit, t: to, v: value, i: initBytecode, d: data }`
+ - `S()`: returns the sender of a transaction eg `S(T) = T.from`
+ - `Λ`: (lambda) account creation function
+ - `KEC`: Keccak SHA-3 hash function
+ - `RLP`: Recursive Length Prefix encoding
+
+## High-level glossary
+
+The following are symbols and function representations that provide a high-level description of ethereum. Many of these symbols represent a data structure, the details of which are described in subsequent sections.
+
+ - `σ`: ethereum world state
+ - `B`: block
+ - `μ`: EVM state
+ - `A`: accumulated transaction sub-state
+ - `I`: execution environment
+ - `o`: output of `H(μ,I)` ie null if we're good to go or a set of data if execution should halt
+ - `Υ(σ,T) => σ'`: the transaction-level state transition function
+ - `Π(σ,B) => σ'`: the block-level state transition function, processes all transactions then finalizes with Ω
+ - `Ω(B,σ) => σ`: block-finalisation state transition function
+ - `O(σ,μ,A,I)`: one iteration of the execution cycle
+ - `H(μ,I) => o`: outputs null while execution should continue or a series if execution should halt.
+
+## Ethereum World-State: σ
+
+A mapping between addresses (external or contract) and account states. Saved as a Merkle-Patricia tree whose root is recorded on the blockchain backbone.
+
+```
+σ = [ account1={...}, account2={...},
+  account3= {
+    n: nonce aka number of transactions sent by account3
+    b: balance ie number of wei account3 controls
+    s: storage root, hash of the merkle-patricia tree that contains this accounts long-term data store
+    c: code, hash of the EVM bytecode that controls this account. If this equals the hash of an empty string, this is a non-contract account.
+  }, ...
+]
+```
+
+## The Block: B
+
+```
+B = Block = {
+  H: Header = {
+    p: parentHash,
+    o: ommersHash,
+    c: beneficiary,
+    r: stateRoot,
+    t: transactionsRoot,
+    e: receiptsRoot,
+    b: logsBloomFilter,
+    d: difficulty,
+    i: number,
+    l: gasLimit,
+    g: gasUsed,
+    s: timestamp,
+    x: extraData,
+    m: mixHash,
+    n: nonce,
+  },
+  T: Transactions = [
+    tx1, tx2...
+  ],
+  U: Uncle block headers = [
+    header1, header2..
+  ],
+  R: Transaction Receipts = [
+    receipt_1 = {
+      σ: root hash of the ETH state after transaction 1 finishes executing,
+      u: cumulative gas used immediately after this tx completes,
+      b: bloom filter,
+      l: set of logs created while executing this tx
+    }
+  ]
+}
+```
+
+## Execution Environment: I
+
+```
+I = Execution Environment = {
+  a: address(this) address of the account which owns the executing code
+  o: tx.origin original sender of the tx that initialized this execution
+  p: tx.gasPrice price of gas
+  d: data aka byte array of method id & args
+  s: sender of this tx or initiator of this execution
+  v: value send along w this execution or transaction
+  b: byte array of machine code to be executed
+  H: header of the current block
+  e: current stack depth
+}
+```
+
+## EVM state: μ
+
+The state of the EVM during execution. This is the data structure provided by the `debug_traceTransaction` JSON RPC method, see [this page](./tracing.md) for more details about using this method to investigate transaction execution.
+
+```
+μ = {
+  g: gas left
+  pc: program counter ie index into which instruction of I.b to execute next
+  m: memory contents, lazily initialized to 2^256 zeros
+  i: number of words in memory
+  s: stack contents
+}
+```
+
+## Accrued sub-state: A
+
+The data accumulated during tx execution that needs to be available at the end to finalize the transactions state changes.
+
+```
+A = {
+  s: suicide set ie the accounts to delete at the end of this tx
+  l: logs
+  t: touched accounts
+  r: refunds eg gas received when storage is freed
+}
+```
+
+## Contract Creation
+
+If we send a transaction `tx` to create a contract, `tx.to` is set to `null` and we include a `tx.init` field that contains bytecode. This is NOT the bytecode run by the contract, rather it RETURNS the bytecode run by the contract ie the `tx.init` code is run ONCE at contract creation and never again.
+
+If `T.to == 0` then this is a contract creation transaction and `T.init != null`, `T.data == null`


### PR DESCRIPTION
- Adds a page describing transaction traces, how to generate them, and tips on how to navigate them without getting lost.
- Adds another page with a symbolic reference for use while reading the yellow paper + mention of a more up-to-date EVM reference.
- Expands the evm opcodes page with pseudo-code for (almost) all of the opcodes & links from the table to a spot for more detailed discussions.
- Lastly, updates the readme to reflect the additions mentioned above.