### PR TITLE
echidna: replace multi-abi with allContracts in configs

### DIFF
--- a/program-analysis/echidna/example/multiabi.yaml
+++ b/program-analysis/echidna/example/multiabi.yaml
@@ -1,3 +1,6 @@
 testMode: assertion
 testLimit: 50000
+# echidna < 2.1
 multi-abi: true
+# echidna >= 2.1
+allContracts: true


### PR DESCRIPTION
Echidna renamed its `multi-abi` option to `allContracts` in commit ff312a6 ("Rename multi-abi to allContracts"). This adds the new option to the test configuration to keep CI passing, while maintaining references in text to the currently available option to not confuse users. A second PR should adjust the text to mention the new option once Echidna 2.1 is released.