### PR TITLE
Update token_integration.md

### DIFF
--- a/development-guidelines/token_integration.md
+++ b/development-guidelines/token_integration.md
@@ -47,7 +47,7 @@ Slither includes a utility, [`slither-check-erc`](https://github.com/crytic/slit
 
 - [ ] **`Transfer` and `transferFrom` return a boolean.** Several tokens do not return a boolean on these functions. As a result, their calls in the contract might fail.
 - [ ] **The `name`, `decimals`, and `symbol` functions are present if used.** These functions are optional in the ERC20 standard and may not be present.
-- [ ] **`Decimals` returns a `uint8`.** Several tokens incorrectly return a `uint256`. In such cases, ensure that the value returned is below 255.
+- [ ] **`Decimals` returns a `uint8`.** Several tokens incorrectly return a `uint256`. In such cases, ensure that the value returned is below or equal to 255.
 - [ ] **The token mitigates the known [ERC20 race condition](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729).** The ERC20 standard has a known ERC20 race condition that must be mitigated to prevent attackers from stealing tokens.
 
 Slither includes a utility, [`slither-prop`](https://github.com/crytic/slither/wiki/Property-generation), that generates unit tests and security properties that can discover many common ERC flaws. Use slither-prop to review the following:


### PR DESCRIPTION
Since uint8 has a max of 2**8-1, the check for an ERC20 decimals function returning uint256 should be <= 255 and not < 255.