### PR TITLE
ci: lint_links: only check changed files on pull requests

### DIFF
--- a/.github/workflows/lint_links.yml
+++ b/.github/workflows/lint_links.yml
@@ -12,8 +12,8 @@ on:
       - ".github/workflows/lint_links.yml"
       - "**.md"
   schedule:
-    # run CI at 09:00, on day 1 of the month even if no PRs/merges occur
-    - cron: "0 9 1 * *"
+    # run CI at 09:00 every Tuesday even if no PRs/merges occur
+    - cron: "0 9 * * 2"
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/lint_links.yml
+++ b/.github/workflows/lint_links.yml
@@ -23,3 +23,4 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
+          check-modified-files-only: ${{ (github.event_name == 'pull_request' && 'yes') || 'no' }}

--- a/.github/workflows/lint_links.yml
+++ b/.github/workflows/lint_links.yml
@@ -19,7 +19,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"


### PR DESCRIPTION
This makes the action only check changed files (compared against master) on pull requests. It also schedules it to run on the whole repo on Tuesdays and pins `actions/checkout` to v3 instead of master.

Closes: #303