### PR TITLE
refactor: remove `public` visibility from `constructor`s + add thousand separators to thousand numbers

### DIFF
--- a/program-analysis/echidna/exercises/exercise1/solution.sol
+++ b/program-analysis/echidna/exercises/exercise1/solution.sol
@@ -11,8 +11,8 @@ import "./token.sol";
 contract TestToken is Token {
     address echidna = msg.sender;
 
-    constructor() public {
-        balances[echidna] = 10000;
+    constructor() {
+        balances[echidna] = 10_000;
     }
 
     function echidna_test_balance() public view returns (bool) {

--- a/program-analysis/echidna/exercises/exercise1/template.sol
+++ b/program-analysis/echidna/exercises/exercise1/template.sol
@@ -11,8 +11,8 @@ import "./token.sol";
 contract TestToken is Token {
     address echidna = tx.origin;
 
-    constructor() public {
-        balances[echidna] = 10000;
+    constructor() {
+        balances[echidna] = 10_000;
     }
 
     function echidna_test_balance() public view returns (bool) {

--- a/program-analysis/echidna/exercises/exercise2/solution.sol
+++ b/program-analysis/echidna/exercises/exercise2/solution.sol
@@ -9,7 +9,7 @@ import "./token.sol";
 ///      echidna program-analysis/echidna/exercises/exercise1/solution.sol
 ///      ```
 contract TestToken is Token {
-    constructor() public {
+    constructor() {
         pause(); // pause the contract
         owner = address(0); // lose ownership
     }

--- a/program-analysis/echidna/exercises/exercise2/template.sol
+++ b/program-analysis/echidna/exercises/exercise2/template.sol
@@ -9,7 +9,7 @@ import "./token.sol";
 ///      echidna program-analysis/echidna/exercises/exercise2/template.sol
 ///      ```
 contract TestToken is Token {
-    constructor() public {
+    constructor() {
         pause(); // pause the contract
         owner = address(0); // lose ownership
     }

--- a/program-analysis/echidna/exercises/exercise3/mintable.sol
+++ b/program-analysis/echidna/exercises/exercise3/mintable.sol
@@ -7,7 +7,7 @@ contract MintableToken is Token {
     int256 public totalMinted;
     int256 public totalMintable;
 
-    constructor(int256 totalMintable_) public {
+    constructor(int256 totalMintable_) {
         totalMintable = totalMintable_;
     }
 

--- a/program-analysis/echidna/exercises/exercise3/solution.sol
+++ b/program-analysis/echidna/exercises/exercise3/solution.sol
@@ -11,11 +11,11 @@ import "./mintable.sol";
 contract TestToken is MintableToken {
     address echidna = msg.sender;
 
-    constructor() public MintableToken(10000) {
+    constructor() MintableToken(10_000) {
         owner = echidna;
     }
 
     function echidna_test_balance() public view returns (bool) {
-        return balances[msg.sender] <= 10000;
+        return balances[msg.sender] <= 10_000;
     }
 }

--- a/program-analysis/echidna/exercises/exercise3/template.sol
+++ b/program-analysis/echidna/exercises/exercise3/template.sol
@@ -12,7 +12,7 @@ contract TestToken is MintableToken {
     address echidna = msg.sender;
 
     // TODO: update the constructor
-    constructor(int256 totalMintable) public MintableToken(totalMintable) {}
+    constructor(int256 totalMintable) MintableToken(totalMintable) {}
 
     function echidna_test_balance() public view returns (bool) {
         // TODO: add the property


### PR DESCRIPTION
# What does this PR introduce?

Since Solidity v0.7.0, the visibility for `constructor` is ignored.
Remove the `public` visibility from all the constructors in the exercices.

https://docs.soliditylang.org/en/v0.8.19/070-breaking-changes.html#functions-and-events]]
<img width="724" alt="image" src="https://github.com/crytic/building-secure-contracts/assets/31145285/a4362671-cca4-4ce7-8b2f-12db9cc315f1">

Also added thousand separator as `_` to increase code readability of number literals: fron `10000` to --> `10_000`.
