### PR TITLE
Update echidna configuration.md to include symbolic execution documentation

### DIFF
--- a/program-analysis/echidna/configuration.md
+++ b/program-analysis/echidna/configuration.md
@@ -375,16 +375,16 @@ Run events server on the given port.
 
 ### `symExec`
 
-| Type | Default | Available in | CLI equivalent  |
-| ---- | ------- | ------------ | ----------------|
-| Bool | `false` | 2.2.4+       | `--sym-exec`    |
+| Type | Default | Available in | CLI equivalent |
+| ---- | ------- | ------------ | -------------- |
+| Bool | `false` | 2.2.4+       | `--sym-exec`   |
 
 Whether to add an additional symbolic execution worker.
 
 ### `symExecNSolvers`
 
 | Type | Default | Available in | CLI equivalent         |
-| ---- | ------- | ------------ | -----------------------|
+| ---- | ------- | ------------ | ---------------------- |
 | Int  | `1`     | 2.2.4+       | `--sym-exec-n-solvers` |
 
 Number of SMT solvers used in symbolic execution. While there is a single
@@ -394,16 +394,16 @@ symExec worker, N threads may be used to solve SMT queries. Only relevant if
 ### `symExecTimeout`
 
 | Type | Default | Available in | CLI equivalent       |
-| ---- | ------- | ------------ | ---------------------|
+| ---- | ------- | ------------ | -------------------- |
 | Int  | `30`    | 2.2.4+       | `--sym-exec-timeout` |
 
 Timeout for symbolic execution SMT solver per formula to solve. Only relevant if `symExec` is true.
 
 ### `symExecSMTSolver`
 
-| Type | Default    | Available in |
-| ---- | -----------| ------------ |
-| String  | `bitwuzla` | 2.2.8+       |
+| Type   | Default    | Available in |
+| ------ | ---------- | ------------ |
+| String | `bitwuzla` | 2.2.8+       |
 
 The SMT solver used when doing symbolic execution. Valid values are: "cvc5", "z3" and "bitwuzla". Only relevant if `symExec` is true.
 
@@ -420,7 +420,7 @@ Number of states in exponents of 2 (i.e. 2^10 states) that we may explore using 
 
 | Type | Default | Available in |
 | ---- | ------- | ------------ |
-| Int  | `5`    | 2.2.4+       |
+| Int  | `5`     | 2.2.4+       |
 
 Number of times we may revisit a particular branching point. Only relevant if `symExec` is true.
 
@@ -435,12 +435,12 @@ the smt solver to check reachability. Only relevant if `symExec` is true.
 
 ### `symExecTargets`
 
-| Type    | Default | Available in |    CLI Equivalent   |
-| --------| ------- | ------------ |---------------------|
-| [String]| `null`  | 2.2.4+       | `--sym-exec-target` |
+| Type     | Default | Available in | CLI Equivalent      |
+| -------- | ------- | ------------ | ------------------- |
+| [String] | `null`  | 2.2.4+       | `--sym-exec-target` |
 
 List of whitelisted functions for using symbolic exploration. When set to null,
-all functions are eligible. If used in the CLI, it will only allow a single target. 
+all functions are eligible. If used in the CLI, it will only allow a single target.
 Only relevant if `symExec` is true.
 
 ### `disableSlither`
@@ -519,4 +519,3 @@ part of the corpus on the `gas_info` field. This functionality was experimental.
 | Bool | `true`  | \* until 2.2.7 |
 
 This option controlled whether symbolic execution will be concolic (vs full symbolic execution). It has been removed from the current version of Echidna.
-


### PR DESCRIPTION
Updated the documentation to make sure it matches with the echidna version in `master` (future 2.2.8 or 2.3).